### PR TITLE
docs: add consent note template for sign videos

### DIFF
--- a/docs/CONSENT_TEMPLATE.md
+++ b/docs/CONSENT_TEMPLATE.md
@@ -1,0 +1,60 @@
+# Video Consent Form for Sign Language Data Collection
+
+## Participant Information
+
+**Project:** Loru Sign Language Dataset  
+**Principal Investigator:** MergeOS Contributors  
+**Date:** _______________
+
+---
+
+## Consent Statement
+
+I, _________________________ (print name), voluntarily agree to participate in the Loru sign language video data collection project.
+
+### Purpose
+I understand that my sign language videos will be used to:
+- Train and improve sign language recognition models
+- Create educational resources for sign language learning
+- Contribute to open-source sign language technology
+
+### Data Collection
+I consent to the recording of:
+- [ ] Hand gestures and movements
+- [ ] Facial expressions
+- [ ] Body posture and movement
+- [ ] Audio (if applicable)
+
+### Usage Rights
+I grant MergeOS and its contributors the right to:
+- Use my videos for machine learning training
+- Distribute my videos under MIT License
+- Include my videos in public datasets
+- Modify or crop my videos for technical purposes
+
+### Privacy
+I understand that:
+- My videos may be publicly available
+- I will not receive compensation for data contribution
+- I can request removal of my videos at any time
+
+### Declaration
+I have read and understood this consent form. I agree to the terms above.
+
+**Participant Signature:** _________________________
+
+**Date:** _______________
+
+**Witness (optional):** _________________________
+
+---
+
+## For Minors (Under 18)
+
+**Parent/Guardian Name:** _________________________
+
+**Relationship:** _________________________
+
+**Parent/Guardian Signature:** _________________________
+
+**Date:** _______________


### PR DESCRIPTION
## Summary

Adds a consent note template for sign language video data collection as requested in #226.

### Template includes:
- Participant information section
- Consent statement for video recording
- Usage rights (MIT License)
- Privacy acknowledgments
- Minor consent section (parent/guardian)
- Checkbox options for data types

Closes #226