### PR TITLE
feat: gloss coverage heatmap CLI (#223)

### DIFF
--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -165,6 +165,29 @@ def data_coverage() -> None:
     console.print(f"[dim]{have}/{len(DEFAULT_GLOSS)} glosses have samples[/dim]")
 
 
+@data_app.command("export-csv")
+def data_export_csv(
+    out: Path = typer.Option(None, "--out", "-o", help="Output CSV file path. Default: data/out/vocab_export.csv"),
+) -> None:
+    """Export gloss vocabulary as CSV with index and has_sample flag (for teachers)."""
+    import csv
+
+    from loru.config import OUT_DIR
+
+    files = {p.stem for p in list_sample_files()}
+    out_path = out or (OUT_DIR / "vocab_export.csv")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rows = []
+    for i, g in enumerate(DEFAULT_GLOSS):
+        has_sample = "true" if g in files else "false"
+        rows.append({"index": str(i), "gloss": g, "has_sample": has_sample})
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["index", "gloss", "has_sample"])
+        writer.writeheader()
+        writer.writerows(rows)
+    console.print(f"[green]CSV written[/green] → {out_path} ({len(rows)} rows)")
+
+
 @data_app.command("list")
 def data_list() -> None:
     files = list_sample_files()

--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -165,6 +165,34 @@ def data_coverage() -> None:
     console.print(f"[dim]{have}/{len(DEFAULT_GLOSS)} glosses have samples[/dim]")
 
 
+@data_app.command("heatmap")
+def data_heatmap() -> None:
+    """ASCII heatmap showing which DEFAULT_GLOSS entries lack samples."""
+    files = {p.stem for p in list_sample_files()}
+    # Group glosses by first letter for a compact heatmap
+    groups: dict[str, list[tuple[int, str, bool]]] = {}
+    for i, g in enumerate(DEFAULT_GLOSS):
+        key = g[0].upper()
+        groups.setdefault(key, []).append((i, g, g in files))
+    console.print("[bold]Gloss Coverage Heatmap[/bold]")
+    console.print("[dim]█ = has sample, · = missing[/dim]\n")
+    total_have = 0
+    for letter in sorted(groups):
+        items = groups[letter]
+        row = ""
+        for _, gloss, has_sample in items:
+            row += "[green]█[/green] " if has_sample else "[red]·[/red] "
+            if has_sample:
+                total_have += 1
+        missing = sum(1 for _, _, h in items if not h)
+        console.print(f" {letter}  {row}  ({len(items) - missing}/{len(items)})")
+    console.print(f"\n[dim]Total: {total_have}/{len(DEFAULT_GLOSS)} glosses have samples[/dim]")
+    # Show missing glosses
+    missing_glosses = [g for g in DEFAULT_GLOSS if g not in files]
+    if missing_glosses:
+        console.print(f"\n[yellow]Missing glosses:[/yellow] {', '.join(missing_glosses[:10])}" + (f" +{len(missing_glosses)-10} more" if len(missing_glosses) > 10 else ""))
+
+
 @data_app.command("export-csv")
 def data_export_csv(
     out: Path = typer.Option(None, "--out", "-o", help="Output CSV file path. Default: data/out/vocab_export.csv"),

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -1,0 +1,44 @@
+"""Tests for #224: export vocab CSV for teachers."""
+from __future__ import annotations
+
+import csv
+import tempfile
+from pathlib import Path
+
+from loru.cli import data_export_csv
+
+
+def test_export_csv_writes_file() -> None:
+    """data export-csv writes a CSV file."""
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "test_vocab.csv"
+        data_export_csv(out=out)
+        assert out.exists()
+        text = out.read_text(encoding="utf-8")
+        assert "index,gloss,has_sample" in text
+
+
+def test_export_csv_has_correct_header() -> None:
+    """CSV has expected columns."""
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "test_vocab.csv"
+        data_export_csv(out=out)
+        with open(out, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            assert set(reader.fieldnames) == {"index", "gloss", "has_sample"}
+
+
+def test_export_csv_every_gloss_present() -> None:
+    """Every gloss from DEFAULT_GLOSS is in the CSV."""
+    from loru.models.vocab import DEFAULT_GLOSS
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "test_vocab.csv"
+        data_export_csv(out=out)
+        with open(out, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        assert len(rows) == len(DEFAULT_GLOSS)
+        for i, g in enumerate(DEFAULT_GLOSS):
+            assert rows[i]["gloss"] == g
+            assert rows[i]["index"] == str(i)

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,4141 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "comtypes"
+version = "1.4.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/2a/65274c13327f637ec13af8d39f2cf579d9ebe7a0e683696b5f05236d2805/comtypes-1.4.16.tar.gz", hash = "sha256:cd66d1add01265cface4df51ba1e31cd1657e04463c281c802e737e79e1ba93c", size = 260252, upload-time = "2026-03-02T23:11:42.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/7c/0eb685107290b6221c03c46d39214a4e42a124189691cb83ae3228257f46/comtypes-1.4.16-py3-none-any.whl", hash = "sha256:e18d85179ff12955524c5a8c3bc09cb3c0d890f1da4d7123d14244c7b78f84c8", size = 296230, upload-time = "2026-03-02T23:11:41.049Z" },
+]
+
+[[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/53/8fc9b0cdc5b7f62746e6a01b85b6461e5ae27f871010a5fcf8fa6950766d/cuda_pathfinder-1.5.6-py3-none-any.whl", hash = "sha256:7e4c07c117b78ba1fb35dac4c444d21f3677b1b1ff56175c53a8e3025c5b43c0", size = 52972, upload-time = "2026-06-30T00:58:04.34Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.139.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "loru"
+version = "0.3.29"
+source = { editable = "." }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+api = [
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "uvicorn" },
+]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+gui = [
+    { name = "pyside6" },
+]
+torch = [
+    { name = "torch" },
+]
+voice = [
+    { name = "pyttsx3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.110" },
+    { name = "httpx", marker = "extra == 'api'", specifier = ">=0.27" },
+    { name = "numpy", specifier = ">=1.26" },
+    { name = "pydantic", specifier = ">=2.6" },
+    { name = "pyside6", marker = "extra == 'gui'", specifier = ">=6.6" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pyttsx3", marker = "extra == 'voice'", specifier = ">=2.90" },
+    { name = "rich", specifier = ">=13.7" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "torch", marker = "extra == 'torch'", specifier = ">=2.2" },
+    { name = "typer", specifier = ">=0.12" },
+    { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.27" },
+]
+provides-extras = ["dev", "gui", "torch", "api", "voice"]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.3.33"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyobjc"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-accessibility", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-accounts", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-addressbook" },
+    { name = "pyobjc-framework-adservices", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-adsupport", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-applescriptkit" },
+    { name = "pyobjc-framework-applescriptobjc", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-applicationservices" },
+    { name = "pyobjc-framework-apptrackingtransparency", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-arkit", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-audiovideobridging", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-authenticationservices", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-automaticassessmentconfiguration", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-automator" },
+    { name = "pyobjc-framework-avfoundation", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-avkit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-avrouting", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-backgroundassets", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-browserenginekit", marker = "platform_release >= '23.4'" },
+    { name = "pyobjc-framework-businesschat", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-calendarstore", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-callkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-carbon" },
+    { name = "pyobjc-framework-cfnetwork" },
+    { name = "pyobjc-framework-cinematic", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-classkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-cloudkit", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-collaboration", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-colorsync", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-compositorservices", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-contacts", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-contactsui", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coreaudiokit" },
+    { name = "pyobjc-framework-corebluetooth", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-coredata" },
+    { name = "pyobjc-framework-corehaptics", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-corelocation", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-coremedia", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-coremediaio", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-coremidi" },
+    { name = "pyobjc-framework-coreml", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-coremotion", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-coreservices" },
+    { name = "pyobjc-framework-corespotlight", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-corewlan", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-cryptotokenkit", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-datadetection", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-devicecheck", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-devicediscoveryextension", marker = "platform_release >= '24.0'" },
+    { name = "pyobjc-framework-dictionaryservices", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-discrecording" },
+    { name = "pyobjc-framework-discrecordingui" },
+    { name = "pyobjc-framework-diskarbitration" },
+    { name = "pyobjc-framework-dvdplayback" },
+    { name = "pyobjc-framework-eventkit", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-exceptionhandling" },
+    { name = "pyobjc-framework-executionpolicy", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-extensionkit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-externalaccessory", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-fileprovider", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-fileproviderui", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-findersync", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-fsevents", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-fskit", marker = "platform_release >= '24.4'" },
+    { name = "pyobjc-framework-gamecenter", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-gamecontroller", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-gamekit", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-gameplaykit", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-gamesave", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-healthkit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-imagecapturecore", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-inputmethodkit", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-installerplugins" },
+    { name = "pyobjc-framework-instantmessage", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-intents", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-intentsui", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-iobluetooth" },
+    { name = "pyobjc-framework-iobluetoothui" },
+    { name = "pyobjc-framework-iosurface", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-ituneslibrary", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-kernelmanagement", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-latentsemanticmapping" },
+    { name = "pyobjc-framework-launchservices" },
+    { name = "pyobjc-framework-libdispatch", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-libxpc", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-linkpresentation", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-localauthentication", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-localauthenticationembeddedui", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mailkit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mapkit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaaccessibility", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaextension", marker = "platform_release >= '24.0'" },
+    { name = "pyobjc-framework-medialibrary", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaplayer", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-mediatoolbox", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-metal", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-metalfx", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-metalkit", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-metalperformanceshaders", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-metalperformanceshadersgraph", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-metrickit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mlcompute", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-modelio", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-multipeerconnectivity", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-naturallanguage", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-netfs", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-network", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-networkextension", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-notificationcenter", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-opendirectory", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-osakit" },
+    { name = "pyobjc-framework-oslog", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-passkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-pencilkit", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-phase", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-photos", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-photosui", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-preferencepanes" },
+    { name = "pyobjc-framework-pushkit", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-framework-quicklookthumbnailing", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-replaykit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-safariservices", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-safetykit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-scenekit", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-screencapturekit", marker = "platform_release >= '21.4'" },
+    { name = "pyobjc-framework-screensaver" },
+    { name = "pyobjc-framework-screentime", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-scriptingbridge", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-searchkit" },
+    { name = "pyobjc-framework-security" },
+    { name = "pyobjc-framework-securityfoundation" },
+    { name = "pyobjc-framework-securityinterface" },
+    { name = "pyobjc-framework-securityui", marker = "platform_release >= '24.4'" },
+    { name = "pyobjc-framework-sensitivecontentanalysis", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-servicemanagement", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-sharedwithyou", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-sharedwithyoucore", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-shazamkit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-social", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-soundanalysis", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-speech", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-spritekit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-storekit", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-symbols", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-syncservices" },
+    { name = "pyobjc-framework-systemconfiguration" },
+    { name = "pyobjc-framework-systemextensions", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-threadnetwork", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-uniformtypeidentifiers", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-usernotifications", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-usernotificationsui", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-videosubscriberaccount", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-videotoolbox", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-virtualization", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-vision", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-webkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/ef/b4e64fe87051e72608ed4134072e832e9eae28d97e9c9bb0870f01a18ac5/pyobjc-12.2.1.tar.gz", hash = "sha256:0b2cf49d24213e7604620c31863e7b4e42770c4442c10e59b18ad951cd200cd3", size = 12148, upload-time = "2026-06-19T16:19:38.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/a2/3878e4783c65eeb72a1c06de1f880ef573b9677198a3142ff5082c0810ac/pyobjc-12.2.1-py3-none-any.whl", hash = "sha256:edbbf9e2e249cd2fa660422c7d72e9fe5be1438deab38c64238b26f4c9db9421", size = 4262, upload-time = "2026-06-19T12:50:03.55Z" },
+]
+
+[[package]]
+name = "pyobjc-core"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/b1/729f7458a63758bd21716648a8abcd9a0c8f2d2e9897763c8a1a1c7fd31b/pyobjc_core-12.2.1.tar.gz", hash = "sha256:7a7b9b018402342cf32bf1956366896350fbe5c0478cb3ef59778f77abed7f07", size = 1063383, upload-time = "2026-06-19T16:19:39.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/87/16564ef5e4568ee0edd9e712d8111dc8b67621d6bb6ff430646ee2d637dd/pyobjc_core-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:24b76a63caf0b5369d4a377c7c0438cd70df81539057af3db839bfaa3579e04a", size = 6484662, upload-time = "2026-06-19T16:04:44.979Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/88/300ad283bed0c971c52dcac6f70113e138169d4ce6d856ddd03d16081e51/pyobjc_core-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a64232bb27ed101d4adc7d42b0e64a6d3331aac7bee7861c037a6777a163f10b", size = 6433347, upload-time = "2026-06-19T16:04:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/b9b0ddffae66996b8779f1f7958adc9f21c13a0448cd3be8d7fe589b5b0f/pyobjc_core-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:af101222762665a4125157906cb4b23f5d5a63d3851d5e0504f72a1eaaa2cfd2", size = 6436004, upload-time = "2026-06-19T16:04:53.257Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/bd309ede07784c6e5fac4b440c90a5f72a66da7859ed303a9392fe8a5f3f/pyobjc_core-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:efe465e3ecc6fc73f7c7622620345d134a8d34564ab1c29d8247e45f4ed55071", size = 6687044, upload-time = "2026-06-19T16:04:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8a/cfa4f56939d554dbb342ec6e5226a441e2f552bc2002a0ddf7705bb11bef/pyobjc_core-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2b8fc0531c27277325e113ac00b8a72a82e6145f0a88175b9425d8de814ff69a", size = 6429289, upload-time = "2026-06-19T16:05:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/42/74/446c89bc18103aaa4a00d1fb85ff8acace9a0dc3f362d9678ebf7571e275/pyobjc_core-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9bef500f979e22d54f9da3aaebf6a48f873234b324858bd69256055a318955c7", size = 6690181, upload-time = "2026-06-19T16:05:06.201Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c7/0121ee4c616af07ad2de8cd1a286f6978dc9a227eb58b7c2e875cb68a1df/pyobjc_core-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:047c226eeb58a2993ace5e8904e71cc9426ee20d064c617f8fbf32717d37093e", size = 6487078, upload-time = "2026-06-19T16:05:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a8/cb9fcc150f97d0bf22a2028f88b24cc35949beb1bcc7b8bc5c17d4401677/pyobjc_core-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1188613805336270279570467e4455b74cb6c0f60913ac74c917ee1c37cfaecb", size = 6733064, upload-time = "2026-06-19T16:05:14.313Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-accessibility"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/4b/b0a0f0183b359a07663ed31a3f790986cf880bda909b623fead15cb2afbd/pyobjc_framework_accessibility-12.2.1.tar.gz", hash = "sha256:1e0ad06b5b6ae623f443d15c11780f97908d5c41fdb79532e96c6a4a76066fd8", size = 34377, upload-time = "2026-06-19T16:19:40.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/b8/6937060aca105b75d17fcc296341c12ad2028ab901af784fec40d92c5be4/pyobjc_framework_accessibility-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b2064190604ed1ecfb05fc6a0fd04b7ceb2d9d3ebd02d6899607b5635ac9b12d", size = 11542, upload-time = "2026-06-19T16:05:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/43/22/28a3096e9bb6332d851a7bb4191d6591088165a8465d3540e82a7f3fd9fe/pyobjc_framework_accessibility-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a906f4d6447a6394f10fc7d77cfb755815fb07cdb97c9e3018bd7c528600df3f", size = 11570, upload-time = "2026-06-19T16:05:17.802Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/0630c4c67f262d3d018aee43d185d8e58a8aa32a34222be3177fe9a8c21a/pyobjc_framework_accessibility-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6814e863cc1a29e62d9ec97f7a9535598e46748b9d734cf0b903d190fe0e224", size = 11586, upload-time = "2026-06-19T16:05:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c4/6966cd83fb01c183d778799de67100761f7ffe9b7de34b543c4b5034c7a0/pyobjc_framework_accessibility-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5213d57f9b1d6a7b452af78f904e3eed1b4372e9a850e772cf275177038c8512", size = 11756, upload-time = "2026-06-19T16:05:19.545Z" },
+    { url = "https://files.pythonhosted.org/packages/be/2a/6f0e49d8a76891f1416e9ee8ca8e89fdc353a2770c6651512803d6de4ccf/pyobjc_framework_accessibility-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:cd6d0740f72f99bea723b3ea0b3fc9c8a4bb15965ecaeca6b534dd5c5c766048", size = 11650, upload-time = "2026-06-19T16:05:20.388Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/ba2f8ad4a4d2b29c35b6370ffdac9dbe1f39552b1c9d8174940814d40b0f/pyobjc_framework_accessibility-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:327885b50b9d7a46844c063330ee8e6d76d1e68916e9eb92a8ad00657baee014", size = 11832, upload-time = "2026-06-19T16:05:21.142Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c7/924357300836590c51614c6fe51a684818a973d88fe07c79088bab802f73/pyobjc_framework_accessibility-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6b229742dc42a337b32314563bb6d2ff8aafdb1ff1c951e86db5918412351437", size = 11640, upload-time = "2026-06-19T16:05:21.966Z" },
+    { url = "https://files.pythonhosted.org/packages/80/27/9eafd7a630657accd3ead893418d5aed203883ec6b2bd85294ae64ceadb8/pyobjc_framework_accessibility-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:97d564e2c7e7b12aaa2acfaa1a22c50b6606d0198f4beb1a641b46f50d2ee8d3", size = 11829, upload-time = "2026-06-19T16:05:22.966Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-accounts"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/14/6086edbaeb0f48ac1b915d38d11a36efd8de918277da86abc2058a50baad/pyobjc_framework_accounts-12.2.1.tar.gz", hash = "sha256:6e6d603e10182238cd77596380262a38cbb0a9141d1eca6bf522b2213c6d6751", size = 16209, upload-time = "2026-06-19T16:19:41.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/2b/f8138fa91af3ada0bae01dc5430f0f3a79daeabfd36e02ac165423f67041/pyobjc_framework_accounts-12.2.1-py2.py3-none-any.whl", hash = "sha256:b86cba0f2a9219a1c57aba6c0f0973f7a06f10bf9ccd39b74fdb567f9b34a041", size = 5133, upload-time = "2026-06-19T16:05:23.786Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-addressbook"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/20/70dad64d397f9ba513a314ad4d1e1f7e4903c21caee98dfab2f7a39aaedb/pyobjc_framework_addressbook-12.2.1.tar.gz", hash = "sha256:bb113fd5bcae93da00d67bf870704d2cfb73da49c4a281249d8a5abf9809aa91", size = 47685, upload-time = "2026-06-19T16:19:42.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/7a/1c3b84602dc52e68d4422088ade9323047d5ed2c8f877d67afb0b90b74b7/pyobjc_framework_addressbook-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9daf115aa1225ebc1d7946a82a7b553ddd4158dc82705e60bb8ca9ae2bb38788", size = 12823, upload-time = "2026-06-19T16:05:25.706Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/01/83d10cdd6bcec2b63ded8dc5dd1036fd0dc8b8bb2f3a00b2c57ea785c32e/pyobjc_framework_addressbook-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1bd586c3aa24345cc9e1cf31a8860cda1298cb92a70fe73b05bdf31cb69edcb2", size = 12835, upload-time = "2026-06-19T16:05:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/50/64/909d16cbf2efcd95807da7b9966d6de35225cad192444a93eb07c1c8de3e/pyobjc_framework_addressbook-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ca9a94a3d27cf9b9ae22ac8fc48bfce392757b283419ac38567eeac73b6f8ffc", size = 12853, upload-time = "2026-06-19T16:05:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b7/ac71ac95e5d1bae7aa4ec67e444683780274b826b0e6cad3d57252b29f1f/pyobjc_framework_addressbook-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:32a21916f38dff86226c37e0478dd86e8e5fa070403f8ca27dedf5b48f30a059", size = 13010, upload-time = "2026-06-19T16:05:28.426Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b4/dd48553aa1daf16768ae3fc8cb168e4b01c29ac4b99be36679e7f0639d5e/pyobjc_framework_addressbook-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:687c1752dd0a3b649444839453c51c3f7ad9b540f04ad6d5e68d94678700d524", size = 12911, upload-time = "2026-06-19T16:05:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/13/34d930ad908a3d9fca0096ab57a231993a0d090038627b5926f09b66a204/pyobjc_framework_addressbook-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6578aaa8015b4e2db6139081efef3ff1c87b9d8b7a2b2ffbd99964b2f0f232e6", size = 13075, upload-time = "2026-06-19T16:05:30.665Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0a/b718c14bae7522cd65e2a4afc23c7e3016a8dd1883b75e6aa93ea86d46af/pyobjc_framework_addressbook-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:73e3b8c88f839a00648b9ce5a35ef184bdd78075ecebeb5e8d6210cf07d7c8fd", size = 12901, upload-time = "2026-06-19T16:05:31.665Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/7e83e806be5f788251c9c93a8c54f3e71f0014d2a48ec66070b47771bf98/pyobjc_framework_addressbook-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1adc06442fea100f8524282891d8358d621b8906bad30cbd61552e5edf92dcb7", size = 13066, upload-time = "2026-06-19T16:05:32.605Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-adservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/de/6e9fa436a7aacaebe664c918dabfad14a19aa0f6ccaf24384d0c0b55b6f0/pyobjc_framework_adservices-12.2.1.tar.gz", hash = "sha256:6668fbef1b383c5cafae8479f4a8b53e824bd4d568611a53a3075e8c6dc4e39a", size = 12269, upload-time = "2026-06-19T16:19:43.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/43/c8d1a8be6faf0b3c60b28f8dbc31198ccbb72acdf0eb42fa8effbc9eaccd/pyobjc_framework_adservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:631eaa86145179631624788ac1ee485fc79c2f9de347ab7d0cb3ea3413cd0cb1", size = 3510, upload-time = "2026-06-19T16:05:33.49Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-adsupport"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/53/d73eafbc080b7eed68917f6a62758dafca80c7a6ac98ef35660185f8ea89/pyobjc_framework_adsupport-12.2.1.tar.gz", hash = "sha256:c659ac447b1bb3b1a54add100d72932cfd50482384a97c22926d281c9d97a6c0", size = 12098, upload-time = "2026-06-19T16:19:43.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e309b2c03498b2d0848382aabea2b068f314c40dc58f1e3dbd5bedbddaf/pyobjc_framework_adsupport-12.2.1-py2.py3-none-any.whl", hash = "sha256:46a18c775a12565efbe46fbd0258ed63aa74002773362ff7d5e5be525013b221", size = 3424, upload-time = "2026-06-19T16:05:34.492Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applescriptkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/04/187611b7f3e51532b45df08c3b22edd53f163f337a88d7c03c4dc904e2ed/pyobjc_framework_applescriptkit-12.2.1.tar.gz", hash = "sha256:fa3a55933ec090aebc695f3575a5afe8a2d37015162cd30e6c00948748d08f83", size = 11668, upload-time = "2026-06-19T16:19:44.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/82/f83a29b54c8fbf5a7a6cc53676767968fa970fa902b599ae92ecf4208fd1/pyobjc_framework_applescriptkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:db6a0aae4d9421068ed8a0838c509e3a7858813975dde40c40ef1dcc15328d1d", size = 4381, upload-time = "2026-06-19T16:05:35.356Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applescriptobjc"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/b8/67273037f4f10334d9660001bf12f5cc8b483f9cf9c8df91aa39701bcce4/pyobjc_framework_applescriptobjc-12.2.1.tar.gz", hash = "sha256:c60b751a6c20148f23eb1d556aa36612c7e39b14e0bd87abaea53744ff8eabc9", size = 11777, upload-time = "2026-06-19T16:19:45.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/8f/d66814f05748297c1c281d3b2f4a96600d4a3de87c65b6abf6a92151cac0/pyobjc_framework_applescriptobjc-12.2.1-py2.py3-none-any.whl", hash = "sha256:59a3f7668b1f88707c06ae1cd263856ac29c2bf1650a9dbfa21288e0baebe298", size = 4479, upload-time = "2026-06-19T16:05:36.364Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applicationservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/4d/0ebdd8144aba94b8fe9828ccee5616a4bf53d1f8bc51cff55f3cce86d695/pyobjc_framework_applicationservices-12.2.1.tar.gz", hash = "sha256:048ea663c9ac75c44a15dc7d5b8d78cbb4c97bf1c76e83835e8d5498e184001f", size = 109342, upload-time = "2026-06-19T16:19:46.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/8a/5a9310929bb303c31c04a1c6dc7b3213c9bd964a692d024a00c0643af2c8/pyobjc_framework_applicationservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dabec481217b0d0c1ea835e9fef6b0681381b14b3f16a30d4a9d801ee3852dd2", size = 32715, upload-time = "2026-06-19T16:05:38.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/89/39a7462006afbc06c69029fe4181b7359a9da25ae7864ef75f9d3ffb9272/pyobjc_framework_applicationservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f519ced13888d03410cd7da1f08fc56ee2944099e607216cef7ca26ecfdef61b", size = 32764, upload-time = "2026-06-19T16:05:39.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/8e928d5e3025529ed92c6eb5fd88a5e6e485cc6df945c541f29b4af7f2c6/pyobjc_framework_applicationservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8749290f796e6cca341d443769b79329dde5d157bcc4413c1f7fdb68ea4a8e48", size = 32782, upload-time = "2026-06-19T16:05:40.284Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a5/c7b5a31777fe2ce7c07b9c16941ff4fbf0a150bf755164d96228d32ccb4f/pyobjc_framework_applicationservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9ee11677fbd6a0987234814c7dde88ffd11242e8c1f76952e6654ea07f2370ac", size = 33048, upload-time = "2026-06-19T16:05:41.308Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/47/cd2bd76b862686c0aa78568ed9dff175764353c209a3096c72d6e2a9b151/pyobjc_framework_applicationservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a1c0ee536cb8bd7f5a811165ec323a9207b1e8dad9534fe2081f767fb90b0411", size = 32921, upload-time = "2026-06-19T16:05:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/6989a96f8501aa3a16513d08b2c4c78ca906a10b6a4e5a33c4c59fd1bea9/pyobjc_framework_applicationservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0d55dd5be19e4a1363662bc8b48894d45714d07f0ee3958665fc9ea7df0f61b7", size = 33163, upload-time = "2026-06-19T16:05:43.256Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/41/66f2bcd12454a85f0479393f5825021332ee84b49583c7954cd20310cab5/pyobjc_framework_applicationservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e91c84238b2f68f608473854bcabb8770f15ad837e7561d217f24a1e482e42be", size = 32915, upload-time = "2026-06-19T16:05:44.151Z" },
+    { url = "https://files.pythonhosted.org/packages/81/cf/04b6b1eb181fa3071e9743bab7551f5d2ec3f650ac74bab790f21717ba51/pyobjc_framework_applicationservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:09bfa27765d4c74155323fd8185b7aba6d639ce06c0a9f00ee2d9e7dce3d7800", size = 33158, upload-time = "2026-06-19T16:05:45.017Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-apptrackingtransparency"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/c3/2f6b30c7010b32450769d679c30393a148d0b1531b31f1c0d3a600fc999b/pyobjc_framework_apptrackingtransparency-12.2.1.tar.gz", hash = "sha256:3eff48469eb07e4637408f410ce2690711f5c3de2fbfaa8844daa718ed3479f7", size = 12795, upload-time = "2026-06-19T16:19:47.034Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/2d/a78781f57f2c28155a60eb5ef255d50a7d34b036d16e395cdbc27c2c02da/pyobjc_framework_apptrackingtransparency-12.2.1-py2.py3-none-any.whl", hash = "sha256:29fb3e38e124932eb566a8427dc0db759eba63396cf530862b081432316ff863", size = 3930, upload-time = "2026-06-19T16:05:45.898Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-arkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/be/db21fafd315dc479925d79bd144f132cb38fb37583212753db8252b765d8/pyobjc_framework_arkit-12.2.1.tar.gz", hash = "sha256:ed4f67b1594a427b66ab751657ce6183a93a07ba32d3ba3bbefd7e0b4f6bf64d", size = 40145, upload-time = "2026-06-19T16:19:47.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/34/439b5e0505a369ab741daf65dee78a58e9110df79bf2fe20883b0c93666b/pyobjc_framework_arkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:2834c497fe9f6cbfcdfdcb0202945b7ad36708438afbc71c77186ce3fb972366", size = 8328, upload-time = "2026-06-19T16:05:47.05Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-audiovideobridging"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/6b/cacbe1a5f8e72c76f546689b551853e9312a00a612e8a2087e75f0dc1e3a/pyobjc_framework_audiovideobridging-12.2.1.tar.gz", hash = "sha256:7b6890ebfb1d346988dad7ff20182373c5c15026b1f9a50f64f654b4ff255e76", size = 44241, upload-time = "2026-06-19T16:19:48.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/97/770348fe032e648c09555b7c9611bdf61ac35a7909abea05980836ccd0c9/pyobjc_framework_audiovideobridging-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c0a62ec1acbf2182e272272a73e16cdc9a8de38d87a6f178c07ede661b01902b", size = 11077, upload-time = "2026-06-19T16:05:48.984Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/18/aa7624312ec1aff0243232c75e8f911441c64c417be5a2fd904b89e705a2/pyobjc_framework_audiovideobridging-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8a96bac7a308bed774a5332069ea013e999fa269d58ea67b67ef31dfde705186", size = 11085, upload-time = "2026-06-19T16:05:49.743Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/75/5221bb910b6d4d91bc0653eafa111fe125ca181da7254b4d1bd5e09dea5a/pyobjc_framework_audiovideobridging-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ceebe03b803be2684412050afc9e661d1e9fc7857ca34f27beff3a11b2cad773", size = 11098, upload-time = "2026-06-19T16:05:50.524Z" },
+    { url = "https://files.pythonhosted.org/packages/39/87/9fbd555fb110f3210a39405c604de75561f68e5cf8e1daeddf4101905f5a/pyobjc_framework_audiovideobridging-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:271d3a0a46cc13437b27c790bc7a5fd9dba8f445a743c243de2b41cc2b396aef", size = 11268, upload-time = "2026-06-19T16:05:51.378Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a2/35db7aed073c8d403b965668c66fa4c84c9557ceb248def2fda7276699d4/pyobjc_framework_audiovideobridging-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ce46d2afc7cc5dacea90dc671c1981d8366239d0aa83f06c0bd7ccb5e8218f19", size = 11156, upload-time = "2026-06-19T16:05:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/49/b7e4728e86dbaca3134cc630876b82c0b1955232015e156e0477ba3e499d/pyobjc_framework_audiovideobridging-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:622afa4c3a12878746d10994ef7536d6c81fba75123b3969613ff23da771e36c", size = 11334, upload-time = "2026-06-19T16:05:53.181Z" },
+    { url = "https://files.pythonhosted.org/packages/68/de/3e3b00ed974a7351d9972273c515b65ce0ec0dc677d1f4956ed6cd4eca7d/pyobjc_framework_audiovideobridging-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9770aad1e6f915fd162ff2f867c21114b134a0341d1ceed7fa067d3b02d47c38", size = 11156, upload-time = "2026-06-19T16:05:53.978Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/71/a32171ea36e8c890dff834f6529912f281062d3f50b73c356e416663101f/pyobjc_framework_audiovideobridging-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:81fbcaff1304d1aac41a5a661736d7f8ddd31b3b1352bc1fe471906956997b38", size = 11327, upload-time = "2026-06-19T16:05:54.917Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-authenticationservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/1f/fa7506fb8df1c30f7a1fddc9812705494421b2064391106dc00cac948ce8/pyobjc_framework_authenticationservices-12.2.1.tar.gz", hash = "sha256:da70cd842a41276e6f9958b1d3e227a3de452e696c56f8e2b439add45e578665", size = 75693, upload-time = "2026-06-19T16:19:49.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/0b/71951c26dc99ccca7afc5297e6805c2aee8842c887f42372355b2e8292f9/pyobjc_framework_authenticationservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d1c679a6625ab639c42a2ea9e69d9b1d13c639effb2fec92176e107f53d4b90", size = 21286, upload-time = "2026-06-19T16:05:56.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/85/5019b9a1768b0b9e002029e036d7028312d5704ea48a18bb39e24d22c0dc/pyobjc_framework_authenticationservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ac2f78923734fb477ec4de4a2bea243ae418b33675c2ee62bf12ae333b31dad8", size = 21388, upload-time = "2026-06-19T16:05:57.874Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c1/98c8ec590df7d76f394b90e6bffacdaadcf30555e34b2955ac3348316845/pyobjc_framework_authenticationservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a3ec1ff47578c7163718aed572fb5d4902f2e33df0b178b01c00797b75802225", size = 21399, upload-time = "2026-06-19T16:05:58.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ee/6775170a378c836767c785b2b99294926c9ddd7f9d38a599e5cef52fe6d1/pyobjc_framework_authenticationservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:19194a7266ed75d9d083cf7e8b3d8ac3b241ae259d8c6cd3b4f68bda70751522", size = 21645, upload-time = "2026-06-19T16:05:59.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/fe/bc580ed2693cfaae762989d90b9d7186b7b53f7c5b5deae94b77f52df0a6/pyobjc_framework_authenticationservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b5b5f66e21df6bf856406dbc984c6400f23b43aef4f22603c7685bf074dc749a", size = 21400, upload-time = "2026-06-19T16:06:00.367Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/02/c5e0b7e5aacfc527ce788d5dd3b836f0a8660fe1bf3af85a5ab7e47f2eed/pyobjc_framework_authenticationservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:90e7c3595fabaf1f905473a553f33572d3bb7d53decc323c18df0a7a2e6c4660", size = 21678, upload-time = "2026-06-19T16:06:01.274Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c0/2824fa1036adb44090d1131e9699d9bfb849f5662a084b579e8a2370ed0f/pyobjc_framework_authenticationservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d431787ad7a9718ab7468411e279ab56e59967744dad6b998be623e3fe9df0dc", size = 21401, upload-time = "2026-06-19T16:06:02.088Z" },
+    { url = "https://files.pythonhosted.org/packages/28/85/ca5af44bbd71fab51bab17c18aa39b258cdb5c5eb22db4bfaefc297bfcb9/pyobjc_framework_authenticationservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fd0592d7257eeb47cf398f4a579a617e977a5b949440a60a34f130c0d811d071", size = 21685, upload-time = "2026-06-19T16:06:02.978Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-automaticassessmentconfiguration"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d1/1124aaf5aa1a35126836c623e30eb7ea47c9e64e758f7c3156aa61dbffbd/pyobjc_framework_automaticassessmentconfiguration-12.2.1.tar.gz", hash = "sha256:6888ec9846d04cb7983525d9a134b838044d9857182fe5404224c3071f4cc64f", size = 24775, upload-time = "2026-06-19T16:19:50.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/d4/cbae4c491afda8ce2bed85a0320cb7cc798fc62c2e1187b18d7eb0529f89/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2fa2291aec48dc6ef7ea1233399427f8cb15c3ec28ed937a8f0f0739c06361d5", size = 9364, upload-time = "2026-06-19T16:06:04.755Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/2e284b1b296745e899d1e920c163d3e0d1a7b1111b8735e3b2f9cb57e5d7/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:742f022d3a43478e6d322ea1d2d608080263de75456b5bae7a465a9f463089bf", size = 9382, upload-time = "2026-06-19T16:06:05.516Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a0/61e92054653173c358b17579058e7e5037679a43d0962fa0296070a0f2aa/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c4c233d052d699cf6db479dd8ac0a741fe920e192adc716121c8f4ff3f0ce864", size = 9393, upload-time = "2026-06-19T16:06:06.3Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a5/a5bfc8caa00251b2b1abc22d3a5ef28f4e40c14fad9a8ea1c4817d568495/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:90942b9e126b67f151f0965ca84e00795724a96971195e910137dff2c6c0a20b", size = 9547, upload-time = "2026-06-19T16:06:07.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/8e/61b26f0be555d71142533c18e21e28d5cc7929b8451f42753fe43c12ba79/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d1117a6d3481c8e5ec9f984d201c356598e116daaa0a5db6341c7f52a30e0d4e", size = 9440, upload-time = "2026-06-19T16:06:08.048Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0b/35c209314ceb17601e01a39e3e47a574ca7a3e536b39a4923aafe2a25941/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:aa564494b074a5020e27b307d73cf695cc9256284996304d9e5d22cf8efb9629", size = 9592, upload-time = "2026-06-19T16:06:08.824Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f0/ef2aa598ea223ad2ea2b295f0e16299d4e1bddac81768a6b6b1d2afcafbd/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:5fea5ebc25b053b979536f1b40d19ad9ea80457f47e3df475709b5ab8cf9d7bc", size = 9449, upload-time = "2026-06-19T16:06:10.138Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/49fee458fba33c76e9db0fa602b694cd893a10e43332c749fe69ff9c0b5f/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:170a62e3635f1ddec3e1ec82694ed7330f3ac659ac7ffefc4cee4770d3cc3242", size = 9597, upload-time = "2026-06-19T16:06:10.998Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-automator"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/2f/6669c037108799e2319894f21e0067c3119c2a185b18ca70aaf645309199/pyobjc_framework_automator-12.2.1.tar.gz", hash = "sha256:6ea468966d911292d73f52672603eee50bb4a3d651094f63de25dd6d5818d347", size = 188942, upload-time = "2026-06-19T16:19:51.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/40/0344eafeffe5b17edad349265349f6046acf1e36db825359cb453feb5d94/pyobjc_framework_automator-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c512602073fbb51e5c2c442628029ca7eb1d19a0c53632dbe9aa1b0c47454868", size = 10043, upload-time = "2026-06-19T16:06:13.138Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3c/296fbea8ecdfb45944eeb427328d729280b1dd1a811563a40d8baa0b6fdf/pyobjc_framework_automator-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:275dad426c9cee7b683fa5f800e2779b565d1a1e75cb82bb79ad2289ed802f56", size = 10060, upload-time = "2026-06-19T16:06:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2c/4dfeec84201af81949f7edf670bffe7e88ce022402cab7f62a8ed2234b06/pyobjc_framework_automator-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b74cc160c2f751885d70b6db4d02506468ee4b149672ce06cace88484d8fa769", size = 10076, upload-time = "2026-06-19T16:06:14.725Z" },
+    { url = "https://files.pythonhosted.org/packages/96/62/349e5b92592094e7fe50fbd46e87fc1b5d1f9e09adb48a7e67d3afe4f721/pyobjc_framework_automator-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c41866f4068789acf653416e61ed914279f0d83e12f62b3d5c7eea658df8dbb2", size = 10220, upload-time = "2026-06-19T16:06:15.914Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f8/7452651974e5c7f7c20b03d25b046ca3883ba649cd26f396ab3fa1c3312a/pyobjc_framework_automator-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c6c203c6468df9d958a2e2c5283518b862e87cf1b5db867471ccbb8d0cb9dd0", size = 10124, upload-time = "2026-06-19T16:06:16.732Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ce/de1866c4e99e45e282a53259a266f10f6f70a606c2ea3c8bca19a8b62f49/pyobjc_framework_automator-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dc742dc85b078fcd40f4a6e68f4d712791245b2c64ade046c78661680cec57b1", size = 10266, upload-time = "2026-06-19T16:06:17.526Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e8/7d4d106e3da67c0235e4ebdcda4b2e4e7fdb4e5c784bff93c836a25bafeb/pyobjc_framework_automator-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:146fa43a474585ec27f7edb70513c1b75c4fae53b4f8bf971e7a45f1d37c093c", size = 10116, upload-time = "2026-06-19T16:06:18.53Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d7/39f36aa3137dd34902c1f496218e1398b80f7acc5222867aefb6859c7f0c/pyobjc_framework_automator-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3da3eac88bd2c1615040eefb6df7f98b8dc120eee08a27b86c5bfee5f295edc5", size = 10268, upload-time = "2026-06-19T16:06:19.388Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avfoundation"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/26/7616f0bc8e4eaaba948cf5d220c8f55e0f54f617a2812392a82f19c30f39/pyobjc_framework_avfoundation-12.2.1.tar.gz", hash = "sha256:2735e4f1c345d2b533541577e292f3ad2f75d19200eff99f1a2db16d78b4f1a3", size = 410329, upload-time = "2026-06-19T16:19:52.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/88/38ccef918dea4188e0001e644f3bc16e26d11959b04838e5e243798f703a/pyobjc_framework_avfoundation-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d3ce4b2bb2ae51ad5c27f1d2f2a623bef8b443bccc34423b5149df010f9f501c", size = 85536, upload-time = "2026-06-19T16:06:21.308Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bb/e427b2fd705e9dabbfa0ab89b863305788906e34064db2bb930f1c3ba216/pyobjc_framework_avfoundation-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f372800274df35f8d964cad0ad6da7636f1b6720e802e28e5a6bc1f16f16f135", size = 85578, upload-time = "2026-06-19T16:06:22.292Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f5/b38da31d9f95770d0f0f9b9724a898d240d6fb630796e04e9682384d086c/pyobjc_framework_avfoundation-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9291848b0f0f66031bd3af2549e1e0cdf43e4872b9c562bd29f0239c6ef2b75f", size = 85628, upload-time = "2026-06-19T16:06:23.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a4/f1bc5fc239015d8fb4414a83592d69b85b8bbdc68f2403c21dbcdcb8ce12/pyobjc_framework_avfoundation-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3e92a8502d389469b1307a6a2c386f20d2e77878c7e35e3e14120596b47eb205", size = 86077, upload-time = "2026-06-19T16:06:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/a2/4a65d749d57dd16b034ee0935b7daa1228e8a735bf920e9eab9f4aaa9f1e/pyobjc_framework_avfoundation-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:043aedd86adbc0a3bfe8f76d1a1ce920539e47b5dd5d965358f93e0063c9a53d", size = 85836, upload-time = "2026-06-19T16:06:25.377Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/49/b9e8f51821a9e5a4a76bea7ab10c2dc1b51b8a141cf4bccbba022f2db19f/pyobjc_framework_avfoundation-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:50e2b65e5c3845eb8ad0d37868a7f040656fe69e6c03f4282670e7dc52ed7a4a", size = 86173, upload-time = "2026-06-19T16:06:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3d/eda090c53a98293d6ad78eb2a0639e9ab402c14555c2d9e3c311fc482051/pyobjc_framework_avfoundation-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3f74e199c933df54020b972b985af5a5d2e63134278ea02dfd81923976500794", size = 85889, upload-time = "2026-06-19T16:06:27.517Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/58/88126080195ab3fc95b08562ce30f9f599bdabf282b3a4e57bd2c8c2595c/pyobjc_framework_avfoundation-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1ec2fdfe6eee51f12e7d933e0109ea8ad553acf4301c01f46b79d0a9d378d705", size = 86232, upload-time = "2026-06-19T16:06:28.535Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/8be6b94ad46e50f7f868b487b98ade01914809cf440d5ec892a16600d5c4/pyobjc_framework_avkit-12.2.1.tar.gz", hash = "sha256:9180734ba1ef34000ee0463727dbb73624cc4610a298447c8200aa8a7515e0b6", size = 33618, upload-time = "2026-06-19T16:19:53.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/d0/595fdb5f088b01f214822b3a36fb2fb91e420a46b5cff52c859ff6817506/pyobjc_framework_avkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5114a50272cc0afb7df802329b498fd4e8340adf5fc0614a251264b09ce3bb14", size = 12344, upload-time = "2026-06-19T16:06:30.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/62/ef72553ed6ff62578f9618551f84d76be247082f9c0baabf8b8672f65f29/pyobjc_framework_avkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f8514a6ca882e55738bf5c2c8fd498b4920b3344481ca6747b32526fe99ac7c4", size = 12375, upload-time = "2026-06-19T16:06:31.682Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/18/9812526e8246048e8873ca243868ed1766e4e25335e33deff79c2802ae3b/pyobjc_framework_avkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7743cd8455031f2580188d6428411516bd927fef619b3764c1450379f030ea75", size = 12387, upload-time = "2026-06-19T16:06:32.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ae/da5f02922f7ea01e4e36cb62029c8ea4110520bb4a0edd3f5b3cf761cb29/pyobjc_framework_avkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9dce2ef4ecb2dd97fecdb25eccf2c1506b5406699e5cf50c3124dc231e6729c0", size = 12575, upload-time = "2026-06-19T16:06:33.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/86/6d8fcdd0a79bfc1486a9db2ff1548eb561561aa20ed11c0e8923a7945558/pyobjc_framework_avkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:eba6105589792316b40ce2b23f4957d0185130daf482c37708424b5e61a5a7bf", size = 12396, upload-time = "2026-06-19T16:06:34.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/28/81aaed729f87f904339f072dd89e5f79807bcfc1ceca0362fbbd1276fb4c/pyobjc_framework_avkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2424165d424359a2eaa4f593fe71864c2aa167efa476226fa0be2d07676be967", size = 12589, upload-time = "2026-06-19T16:06:35.11Z" },
+    { url = "https://files.pythonhosted.org/packages/40/15/82a1e4f9400894e09353f2f6a2faba85ea27d0b3e2bad9f6308ee1f62d44/pyobjc_framework_avkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3cf369d8a7afc4585a6abdc8f13fc7bc41da3cba36459fcd9cd3b7fa8f7968d9", size = 12386, upload-time = "2026-06-19T16:06:35.93Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/5a/620afa55572fd2302c6a3495a26c6ba6f781c4e0c559607348507b5aced8/pyobjc_framework_avkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fc3994a696f550393558dc974b7c8f72dd8ca43cf645e5c755f7d5ac167dc93d", size = 12584, upload-time = "2026-06-19T16:06:36.937Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avrouting"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/74/75a7a33349407c3801fd014cfdfa6ceb3e8e83a020277d5e99eedb3a3728/pyobjc_framework_avrouting-12.2.1.tar.gz", hash = "sha256:8fd237f7a5c8d905f194fcdfeb6771e69c7106fc544c24e9725d952505f0fdc7", size = 20905, upload-time = "2026-06-19T16:19:54.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/63/6a6b596706bbe9335e8fc1b6d41f89afd94b09d876d69a9c77b6aabd2085/pyobjc_framework_avrouting-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccdd40b590221f2db3969bfc84782cb720163647b2e8aa4c6c623c59a4e07740", size = 8476, upload-time = "2026-06-19T16:06:39.353Z" },
+    { url = "https://files.pythonhosted.org/packages/df/73/b54c6d24904c3a2eef50a12f3ec0d77d7e2d74567164e088a26b3aac629a/pyobjc_framework_avrouting-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e31a7399fc04d8cdc63f2cd26809dc670acfd6bed4674288df4622c18123a43", size = 8493, upload-time = "2026-06-19T16:06:40.129Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fd/69f18627456e0e9e5bb2838bd1c015c662fa351adb6162d03337a52eec81/pyobjc_framework_avrouting-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2678d7f058cde4156c6c78cc87d71636c432071d0eee10c0d4263a21e6ef23f3", size = 8509, upload-time = "2026-06-19T16:06:41.098Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/8d8122f40b14c69cdc6a86d5211998ecda10cd86bb3fa9c9f27c00c6c3f3/pyobjc_framework_avrouting-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:00401319b0fc450af6ea673af2733543b5e4a4e85b53a8ba15e42106f77a645f", size = 8673, upload-time = "2026-06-19T16:06:41.925Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/1fe8aec1f8c37a331fe9ac7abff251d26b5211e941bec8f5d70ddb41d825/pyobjc_framework_avrouting-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:849822d569032704d68d28eb6395c8e7bffac6966c9212066f5939e1844df5bb", size = 8566, upload-time = "2026-06-19T16:06:42.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7c/1a31edec8cc1f6cfb41d4a70ebef488d04e5ea22facda4699bc05541ddd0/pyobjc_framework_avrouting-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:58b73bb613e6c7dc26c76a6ae2ab759dd58207847c333d9b1d0fa384bd2fbd61", size = 8728, upload-time = "2026-06-19T16:06:43.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4904ad65742b3b751291478d89a83367433a01569966bc24941ca65909ee/pyobjc_framework_avrouting-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:1e112761fdaf8fa4558d908aa70b71b2ac1c3d867dd87217eaec7b2c884ac792", size = 8557, upload-time = "2026-06-19T16:06:44.582Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/6b/0d2392882edf18c6441c25b40e86a455a67a7710168c0f307bdc4128cb68/pyobjc_framework_avrouting-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:835f4c32a2ee715e1ce9b694e448279bad9c1912e23725323acb0f5d8b968716", size = 8726, upload-time = "2026-06-19T16:06:45.504Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-backgroundassets"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/92/2b680e44df5d3a81a2431acfbf6eb2e6fba93f1c382651a77040060d4a83/pyobjc_framework_backgroundassets-12.2.1.tar.gz", hash = "sha256:771fc7a45a10a4b4afb5465b1528958078f456629b63c36a7a43505f93acbaea", size = 29376, upload-time = "2026-06-19T16:19:55.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/02/9200ca88a64e1f0c74330c45610761914d5814aec48bf457d1fe6f9fbb78/pyobjc_framework_backgroundassets-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:071058cbf4a83f11d5abf39d04fb2e449938eb2c2180d4c9f4dd0568577c6c2d", size = 10928, upload-time = "2026-06-19T16:06:47.161Z" },
+    { url = "https://files.pythonhosted.org/packages/19/32/9a08bc3f2aa8eeb5d5be2801a5766a755856b079b3e7afbc1fe31d679dba/pyobjc_framework_backgroundassets-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dac0d3a65a95ea886598f381080c4efffc3acfabcca3e692550fbe615627db7e", size = 10942, upload-time = "2026-06-19T16:06:47.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/89/4e42e961fd771db5c4ba3243ea499926b8242c681671818dcb613f41add7/pyobjc_framework_backgroundassets-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bd07fcd0324ba4c6ba00c0eb3af6832f102e51895afd1933fe9c0c2efe9b9734", size = 10965, upload-time = "2026-06-19T16:06:48.669Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d8/c05a4e2433c1eb61773fb4f4ff46ef6dec4926af4aa98c8a6776bf3cb95f/pyobjc_framework_backgroundassets-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2730c6e01c16d9c42cc46b0c23d37b3ce9de70cd0a93a2f712f44a84bd786bb0", size = 11218, upload-time = "2026-06-19T16:06:49.531Z" },
+    { url = "https://files.pythonhosted.org/packages/11/36/0c38885fb8e03428c5d451453830f91386f7522087e4e4919bbfe9e1375a/pyobjc_framework_backgroundassets-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9b4cd5797eeaae395ab00da89a141396a3f8c29bed13481ca52cbd66eba07406", size = 11013, upload-time = "2026-06-19T16:06:50.321Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6a/aee1901a06775f0a8716005fcab6a6ebd38b66e8dcc3d864b7414b23326e/pyobjc_framework_backgroundassets-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e315f1e22c54603dfd7a924a916cee4975c444ed097e34c5e4f2667e50ddc471", size = 11218, upload-time = "2026-06-19T16:06:51.236Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d4/75270e3d290e6387b61ef780629daf5f40f5f5eef85049db0a91c4187196/pyobjc_framework_backgroundassets-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:16573c33421d45b7eb5354c7ce1d2e21141404c93d3500cf4702ab37e1372dee", size = 11009, upload-time = "2026-06-19T16:06:52.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/8a564b1bc0fe6d8a308eb7c7a72cf9fde0b0f7bf8461d4b1d7292bb7ff83/pyobjc_framework_backgroundassets-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b848dfe93b3afddae60c5bd9b6b899c51f89591faebe3e7788b37928aead2d5b", size = 11218, upload-time = "2026-06-19T16:06:52.845Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-browserenginekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/45/955a13e96d79e369754a99ad185b59edb721e95196a893f215f299bcb9bc/pyobjc_framework_browserenginekit-12.2.1.tar.gz", hash = "sha256:6e07b9582fb7e9b9a9ea40280d5815e4130cd0f9194fdc6bdd3a3bc07d6d2f85", size = 32607, upload-time = "2026-06-19T16:19:55.949Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/ac/25182295ad94f504b1ab99f291e377d0e54ffeda7f95073a257403cdca43/pyobjc_framework_browserenginekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ca3005e7b6bbeb790c9604eae3ff1f3f1bb6aa9e524a9b36606904147f0c2596", size = 11740, upload-time = "2026-06-19T16:06:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ff/f2ecf8207db7a91a7ae778d041cce343e847ee63fc5975fbe1d53d9b62a7/pyobjc_framework_browserenginekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a57b1e941107346d8b948201501654541ed40a361dac81c20c154d428b8a0c37", size = 11760, upload-time = "2026-06-19T16:06:55.761Z" },
+    { url = "https://files.pythonhosted.org/packages/18/98/ad604a0a16bce24d8297d4a651d6ad207137df507f59ff69271fad084bfa/pyobjc_framework_browserenginekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:eb7148c7f32c98d40046eb3338f7ceb1ab055edb122065a7b37cbc84865aa41a", size = 11782, upload-time = "2026-06-19T16:06:56.666Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c8/baae0dc88d8f52cfbdc5623e9ae718fc44c9d72b1c9edbd85a525fc47c6f/pyobjc_framework_browserenginekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:52b212f57572e5d3b31b2dafcbe6e1e47c4af025cb396aba90ac74101ae0e717", size = 11949, upload-time = "2026-06-19T16:06:57.487Z" },
+    { url = "https://files.pythonhosted.org/packages/95/20/e636a02bb9ee6b546054aa098ff8ff4d66e62413a91d31ac78e229b9717c/pyobjc_framework_browserenginekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0b55960a96fe709ba9362638e794a887afd8c66ebcd75ccb758b4bf87233a249", size = 11830, upload-time = "2026-06-19T16:06:58.255Z" },
+    { url = "https://files.pythonhosted.org/packages/64/df/d2a7a7fd5ab5d86dda2256c891ae96c722c53099f8875fd09a06eef74904/pyobjc_framework_browserenginekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2884addef8f1f987cc625f4f123dde6e8e3eaf58915bc2452aa4090c24388338", size = 12021, upload-time = "2026-06-19T16:06:59.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/dc/ce1b20bacc0dad78d864f0b350e97a38588d02403f629aed1616ca23b97e/pyobjc_framework_browserenginekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a20ca22bd18a0d773cd483499761690cf00a6241a5a3186dd407e52ce054a36d", size = 11824, upload-time = "2026-06-19T16:07:00.051Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2e/8f3a89bab39a61cca4f707f3b7f09b650b2a94040c438a29d621484669b9/pyobjc_framework_browserenginekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ca3a58c7be5463c65566d2b41d18cf5b9f0a1f70f27540c1a108e74d2487f1e3", size = 12016, upload-time = "2026-06-19T16:07:01.071Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-businesschat"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/26/c92176248363ef510e991c7b537de7aaa4c66b232de1d6c7c527270d9911/pyobjc_framework_businesschat-12.2.1.tar.gz", hash = "sha256:2847c422d202fb8e1eb892c7151b2251b2880a5e6618b7affbdec2b5521a6072", size = 12409, upload-time = "2026-06-19T16:19:56.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/58/cbe465cb6fcd155af2de412982e59ee9cc354be1b477cb0441e089613f57/pyobjc_framework_businesschat-12.2.1-py2.py3-none-any.whl", hash = "sha256:61ef7e7fb1846a1731c7e7268e032ed6fd2e6df3de195c6c35d4df4c81e18801", size = 3501, upload-time = "2026-06-19T16:07:01.885Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-calendarstore"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/f7/65fe8ddcfd0e88442139b9dd737184aeb6f83d6748315061190ecd0987ad/pyobjc_framework_calendarstore-12.2.1.tar.gz", hash = "sha256:5659f2d59dd49423d3880295cd4b395a61c0b7aea8db654e63dab6dd32d28dee", size = 54448, upload-time = "2026-06-19T16:19:57.485Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/30/f11d28e0d4bea633a5a99e185b5574a8a04a0944372d05bd0a28167f2156/pyobjc_framework_calendarstore-12.2.1-py2.py3-none-any.whl", hash = "sha256:d144a2e2b2566b2954f0e365bf7592ccd17cb459165805ed73c6ed8d0feb2ede", size = 5312, upload-time = "2026-06-19T16:07:03.099Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-callkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/0b/0cef47cd370e195c113125205e83443e23a1da838df7419ad9131539b266/pyobjc_framework_callkit-12.2.1.tar.gz", hash = "sha256:66dfbb864c6aa253ff90ac91cdc23dc7158dee8eb76b1764126f2eae59e771a8", size = 32653, upload-time = "2026-06-19T16:19:58.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/c3/29d18f69cf2478b241844e303cf176e906eb1085795a2fe57e37b8679888/pyobjc_framework_callkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c3ebce966fc18c2d1a0aa36899f4c33c10b190e8b310d03649a65f61e437b91e", size = 11330, upload-time = "2026-06-19T16:07:05.031Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/6a/27a76b1153822a64624dffb9cf93e0f815e3e8d618e4c6e49101cb602645/pyobjc_framework_callkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e259627de99e751d2f05f39d135281a58f75a18d3c5ba9dda27c6bf88bc673a4", size = 11387, upload-time = "2026-06-19T16:07:05.784Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a5/c05d4ac28acdbd24c0eb80b73f6a2968943892a624a90289f7d46c07205d/pyobjc_framework_callkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:afeea8cf2d302994481ebc4e7889168138b2ba82892496866135ad666023e1ed", size = 11402, upload-time = "2026-06-19T16:07:06.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/2fe9ef2735187d4f587a7ae698de5eb34fdaa5cbdc1abb771b3c62d9e3b5/pyobjc_framework_callkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9cc081df5897d0253c4924ff6da6f7c5c03ab6bca07302c99eea6e26738050a4", size = 11616, upload-time = "2026-06-19T16:07:07.628Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5b/4be62a9902ac84c347c893583615227ea479dbf94edf6bad51c314ff94fb/pyobjc_framework_callkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3c0bea7ed9c38d1c5e4a5ebf01a99b93e3eb9cee83ed3de1c3386ce2294bde55", size = 11387, upload-time = "2026-06-19T16:07:08.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e6/a542b46d954429de9f84e164877abd4cba65441792b31a6f39a087c77993/pyobjc_framework_callkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b26b5ab9f54dcfd629458a85d53288595df40aac2c51df0493c9e03967f9cf29", size = 11616, upload-time = "2026-06-19T16:07:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9a/d85b65ff7708699141b4af62be7def5fd1cbc5f82b0ccb0f74642a7488a0/pyobjc_framework_callkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:40d424890b084261ffb8f17f68b815c4724e529d985b88281eb48c76a325c148", size = 11394, upload-time = "2026-06-19T16:07:10.044Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e4/08d9e342c89c3f96f0783edff6192fafd56f5cfabb23323bf35ccbae832d/pyobjc_framework_callkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:446f8c3bc014ebea37e191539971b1dc39f10a259db0e7d552e738249ae43252", size = 11620, upload-time = "2026-06-19T16:07:10.957Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-carbon"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/1f/c5df0b0f276542be355e56541af59ae77e98b22e5265d483601a2324c4e0/pyobjc_framework_carbon-12.2.1.tar.gz", hash = "sha256:a14ca4a45e697c2d187753bc851f3bb49d5bcf66d4ef1d2363fd9962417d8638", size = 39755, upload-time = "2026-06-19T16:19:59.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/6ec19751ee486409164e94ca6bba29050c491467540cefed1398ac520c09/pyobjc_framework_carbon-12.2.1-py2.py3-none-any.whl", hash = "sha256:603cf2bced196dd90d6400bcbca32ab573166fc4058193bfbd7c1bd95cdefd4c", size = 4646, upload-time = "2026-06-19T16:07:11.76Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cfnetwork"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/96/189e013d494489e6468d9b0b81c4b0e2f338574e1a777b7a43a6b37573e6/pyobjc_framework_cfnetwork-12.2.1.tar.gz", hash = "sha256:cadc9f65a97c20cf839259229c34ecdb5b54a3ade816c43374a1eb25d3900925", size = 47652, upload-time = "2026-06-19T16:20:00.352Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/6d/7eba39749600eb43df55445be2947826255469aa07402829c3fb23c6c9c6/pyobjc_framework_cfnetwork-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045913bd2535281a16be306fe87e0cd419a98273f44abb7e7058d67d71083324", size = 19975, upload-time = "2026-06-19T16:07:14.066Z" },
+    { url = "https://files.pythonhosted.org/packages/77/15/227b45b0780c1a0bab0b1e7343a59871d393150661e7e28b9e980c959a71/pyobjc_framework_cfnetwork-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f9be16c691c6f1f58e91551c9e67069abcbf3d5e9a789b1b95b1f84620f0308f", size = 20155, upload-time = "2026-06-19T16:07:15.201Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/17/1565bbd61caedeba02f86871a9db0dc3e103e5c0cb2e4264089741e4dc79/pyobjc_framework_cfnetwork-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e8efd441705148fc715c18e57c30c68da001465d2c443decbc56bd4417a8725a", size = 20173, upload-time = "2026-06-19T16:07:16.147Z" },
+    { url = "https://files.pythonhosted.org/packages/64/92/1d1fe63cad93c423f85ae41471bc1992902a7c3a90b106b1907fd460061b/pyobjc_framework_cfnetwork-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d040fd88f3b8e60f7c35096b0901cb6f05c0c5a7f0c90af783fab5547bed3061", size = 20473, upload-time = "2026-06-19T16:07:17.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f6/4af038de8529f9d13ed896b25d9923005bfe70d3b29053b515d484f7c639/pyobjc_framework_cfnetwork-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d9a9399799d5889b0746860c1ebc569b813e3fe836d80d19080901a966094121", size = 20218, upload-time = "2026-06-19T16:07:18.089Z" },
+    { url = "https://files.pythonhosted.org/packages/28/8f/642e3270ba88868cec357a00f5641d448159287c1df896b10315328b8ef9/pyobjc_framework_cfnetwork-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:828d104edb558be33667ce3fa9cc37a853839fadcb10bed7017709b0511d8801", size = 20454, upload-time = "2026-06-19T16:07:19.104Z" },
+    { url = "https://files.pythonhosted.org/packages/28/21/5a0e30a9fcce01796cd1539d277e912729766723384b509efb2428fbdf30/pyobjc_framework_cfnetwork-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:89725cfeeb24fb277be2944c81f2f6f9dedd4da25c4af26a3d7b4aadeb421734", size = 20218, upload-time = "2026-06-19T16:07:21.604Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/9edc4c12f9445d43e98d13812495098d9d342e9d9ab6e9b1d9aa57bd3d0b/pyobjc_framework_cfnetwork-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:eedf28c9e2b69607e646b775bf2149835bdafac9133847c561e00e0c87e0e9e9", size = 20459, upload-time = "2026-06-19T16:07:22.742Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cinematic"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/a942906b8753161e58b89e6d986dc24a435a8cbe6ab6ea80162d31b37895/pyobjc_framework_cinematic-12.2.1.tar.gz", hash = "sha256:cd251ded9393ff4a993a3689d4d3ce7ba3926e7f884f9cd333cf9610338ac28b", size = 24948, upload-time = "2026-06-19T16:20:01.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/e4/9a0d9725de7a31c08eb470b6ccd9c5f3628b972a6309b3214406ed9f74cd/pyobjc_framework_cinematic-12.2.1-py2.py3-none-any.whl", hash = "sha256:73720492fc29eee04cbbeae701dd21c5ddd56dc4e19e59b2af520b8f53a129a3", size = 5123, upload-time = "2026-06-19T16:07:23.663Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-classkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/33/d2933e1dcf122be5b785220713c80cf07a24d2e21bd429b39d723059f653/pyobjc_framework_classkit-12.2.1.tar.gz", hash = "sha256:2f14c6056486b274e487deabf2ce94ccf17db5df6cd332617592ff2d306d7b5c", size = 28972, upload-time = "2026-06-19T16:20:02.296Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/f9/1ad14ee12321a13eed23edd20e75af14ef62a3676459dc9dc8f8e3586ba2/pyobjc_framework_classkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:63b2669246b0545c0c8357cc73294fac902bfc8a69617b3012395dac974c0ec1", size = 8934, upload-time = "2026-06-19T16:07:25.787Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/62/2acd49bb925b8785a2051825bae02d7db2e92d7fa1573585ccdeb131e76c/pyobjc_framework_classkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f39c78209ad615bb1ef54a3b78b56438aa734bb01143d954ab29d9cee59ec34d", size = 8950, upload-time = "2026-06-19T16:07:26.848Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/2a/b7ff453762489443997a3d39d5b6e6865c736ed57db7be67cfab982106fc/pyobjc_framework_classkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b96d7b6416e954be53ac4fc1908bad22c6609d116dd50ef1f25f057bf8274625", size = 8964, upload-time = "2026-06-19T16:07:27.966Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1f/83661aec2aa68f7c571370230a0dcca12f2c1b6bf615ab96ffbde12c2ea6/pyobjc_framework_classkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d689fb7bcf0120963b0d4518399c2440a4bf95378e9841289835846008bebac2", size = 9111, upload-time = "2026-06-19T16:07:28.953Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9f/b5ad19a4570757500433263c135408160c500301bc9aa09fe5a2c5598659/pyobjc_framework_classkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ad7e412ab76fc061b0ac40d98bee454cb4e211ca4ac8d0615a42d2e585ff927e", size = 9029, upload-time = "2026-06-19T16:07:29.838Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/3a/0919a7c440882763f333534c84cd6ff2c65e980e7e3039d55f87573d2e0c/pyobjc_framework_classkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0cf34015821023ea317bad59087c44bb63c3e8be14177904f7204bd1e53cf8a1", size = 9183, upload-time = "2026-06-19T16:07:30.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/34/8f9e45ebab8eacdcf2d69e355719b20f7b36e20fcd02948f59bf2857138b/pyobjc_framework_classkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:5b65626323c4e8fd51b85b0474a4a2c10fc4eca097857406837ca1570310fb34", size = 9030, upload-time = "2026-06-19T16:07:31.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/99/9cc70a07b4f44c484d66fc800198043dffb65924b5d50ba2eac865e3c2c9/pyobjc_framework_classkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6a71f9152dc08502fb299d664afde0936682e60b4023a887fcec6eb485dbe91d", size = 9180, upload-time = "2026-06-19T16:07:33.292Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cloudkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-accounts" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coredata" },
+    { name = "pyobjc-framework-corelocation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/3a/ff99bc394e051086f7d63ade09460de85e2540cf823fb1cd759225f2c744/pyobjc_framework_cloudkit-12.2.1.tar.gz", hash = "sha256:7d3810347fe8de6171d8a4377916750b4ba3bfa874b5f8e5bd0ca6e62d2c4f43", size = 71962, upload-time = "2026-06-19T16:20:03.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/3e/093157f31d29e06bad916d12f6903bcae9c7708ff89fef5bb612cf305f44/pyobjc_framework_cloudkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:4badd0d3b9d78fab900415a2b0319579c5be3a30fa99e631a9065f3768076e35", size = 11437, upload-time = "2026-06-19T16:07:34.479Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/d6/dc66ea8519a0475efbccf73f82cc28066339bb300a27f5e1bf91ab1d7002/pyobjc_framework_cocoa-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dc6da84f4fc62cc25463bbb85e77a57b8d5ac6caf9a60702daf2edb601332f15", size = 387298, upload-time = "2026-06-19T16:07:37.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/cf/1b3b32b2f28f66cc053c3438ef4e6df36a1591945bf05e7399da18d74553/pyobjc_framework_cocoa-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:28b9b8bab1c36efb94744786918752d0c1842f5fbb67e7d5ca97b5f736512080", size = 388113, upload-time = "2026-06-19T16:07:38.9Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/46/68e8e4d926a2f70fed0437047bc3f9fe08af8fe620d94d80656ebc3cfa9b/pyobjc_framework_cocoa-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b74a78fa7803e547b32e5e8ec1b49987b52fe318383e793bc6cd49b80efbd9f", size = 388183, upload-time = "2026-06-19T16:07:40.483Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f3/dfc9af4c9eb2e5389c860ad5ef252be9fe456db09f39d537555dc5057aa1/pyobjc_framework_cocoa-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc2eaca2f13c7bcd8e41e51a372e47825dea9dd3126108760eed7ba883d2945c", size = 392275, upload-time = "2026-06-19T16:07:42.078Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c8/b90baa8f3592eded79b4be98fb59d2b8dc16b62361e34292bd95806ebd9f/pyobjc_framework_cocoa-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b386c324d64ae565c1f6b7dfb77be68f640a1c7c23caa6966ab661131f519561", size = 388357, upload-time = "2026-06-19T16:07:43.364Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/64a94651b9294702d55e748d94de30e25bc59d0784526be7643f4467eccd/pyobjc_framework_cocoa-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a6c584e2af0813cb2f6103b184e632665a26f58c1bd5b08ffd6e95a19c617f7b", size = 392404, upload-time = "2026-06-19T16:07:44.955Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/cc/26e8a7bf1f5e8caa38b7f80d486296f9fd3c97e71ad7e5444ef22e802758/pyobjc_framework_cocoa-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b6023657b8d6cc049a21bd6b4752425f2f53c42f9f0b02d64c7608cc484bf103", size = 388589, upload-time = "2026-06-19T16:07:46.276Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/eedf743a303ea742b8e082afe3613fb4d6618bc1a48cf2568b004ce906f7/pyobjc_framework_cocoa-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c685ccd8e266a07cf912a2c5a13b1f2eff2a868a1aff163b4801b4687bd425e1", size = 392691, upload-time = "2026-06-19T16:07:47.477Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-collaboration"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/b0/9cd5d547543a87ab199a5dc6e4c489b01b825994b52b0d17d89abd7219c6/pyobjc_framework_collaboration-12.2.1.tar.gz", hash = "sha256:d293b191823cf8c5cc17e74279e640312961a9226da97e6258580d1b6085e1e4", size = 15065, upload-time = "2026-06-19T16:20:06.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/bd/7803dd4c6c472a610cd83f7ad7136b61b8bb3dab803a35a6ca4ed0561688/pyobjc_framework_collaboration-12.2.1-py2.py3-none-any.whl", hash = "sha256:03404e679dc77314ea94029c8e54dae25424194b5f39751fb6fa0eca4af99fdf", size = 4880, upload-time = "2026-06-19T16:07:48.59Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-colorsync"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/dd/8f292cc041fb2a836a3ee7432c3f64347a15b5b4d64278277e4954ba28e1/pyobjc_framework_colorsync-12.2.1.tar.gz", hash = "sha256:1e682586a319f49d3ee3c93e54a527a1ff93de06f653e77c0c4ff4d9671469f9", size = 26902, upload-time = "2026-06-19T16:20:07.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/99/9c1d4d010cf51b17aba298664ff2dac7818a3d568202d36b0587fd07fd5a/pyobjc_framework_colorsync-12.2.1-py2.py3-none-any.whl", hash = "sha256:0bafd1bfdf77687910e4a6f01c640ec47def060fb88e3abaddf4cd7e7d469e87", size = 6028, upload-time = "2026-06-19T16:07:49.817Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-compositorservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f3/2136460770ff0b32e64282eed79c37a07c1dfa9df761f2679462391d4ada/pyobjc_framework_compositorservices-12.2.1.tar.gz", hash = "sha256:683b765077ce3bf9b680bfce23124ace85208738ff3c14768e1ca80fd78c1565", size = 24941, upload-time = "2026-06-19T16:20:08.032Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/0a/2e3177c354db49ffe137410431baed816fca9101bee9da808a5e5cbab9e9/pyobjc_framework_compositorservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:1c1cc5ca97e060afe2125b338651d5143f8f6b40e17748116dedc334449773d0", size = 5995, upload-time = "2026-06-19T16:07:50.803Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-contacts"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e2/a9c33480e4f6de3f20e2d2668ea05520061b8eae31e8461b09940c01f2dc/pyobjc_framework_contacts-12.2.1.tar.gz", hash = "sha256:b009f1e85d672e659c30cefbba02a1825b4ca2b604e65826445fb8620159725e", size = 48701, upload-time = "2026-06-19T16:20:08.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/b9/6793fe551d7c2ddf202b6a787debf6d3da251ef8f13f4fd49e83ba92d512/pyobjc_framework_contacts-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:01fea11ba777721add31ccff3497334eb0fde7ba1c69cf2c845a85e1515d5c18", size = 12089, upload-time = "2026-06-19T16:07:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c1/c4435f4dfb8ef0038a9556d2472cd259322f73627c21f94f3e233bd73587/pyobjc_framework_contacts-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9e31c635d1a8ed48d0e3332120d0eafa6a5d40b30fe4832aaa700fa03fe14c8d", size = 12172, upload-time = "2026-06-19T16:07:53.999Z" },
+    { url = "https://files.pythonhosted.org/packages/50/0a/9a518f0ebecd5e27493230de7f5dc746b7abdf0ae3f192a14abc7c23cd15/pyobjc_framework_contacts-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:93facd1772971b6d88243fa28781498ab5f479c0fe286f8c03870f93c515b517", size = 12186, upload-time = "2026-06-19T16:07:54.774Z" },
+    { url = "https://files.pythonhosted.org/packages/73/74/57cbdbe46884d890e8321a9ea3cb85a163def2e0100bc38e14b41cdcde35/pyobjc_framework_contacts-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d0f73ff7f92986b5920155e9cb16bc74cf049e166e6bc2a7df1621135b4e6d79", size = 12351, upload-time = "2026-06-19T16:07:55.543Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a6/3fc0bc4c50fdf5005501c276613d39c09a35e236f8d5c8f344ae914895eb/pyobjc_framework_contacts-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:31d0906bce2e5c348a1453ac390d9e255ce547ca763e93875ea3582deba69070", size = 12259, upload-time = "2026-06-19T16:07:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4b/31ca64f27d6d9fd1ee2efed4bc979abefc21c743d6b7eab1257c2de2d359/pyobjc_framework_contacts-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:85ec30abb7b27655c715e3b2e01ed6229e24b7f14f235e6c04fb77afedad3983", size = 12415, upload-time = "2026-06-19T16:07:57.705Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/51/9b4ec4d4c5a316a2fd3fe6d70c10080e82a4af95e8ffc229f1d04285b60e/pyobjc_framework_contacts-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d21bce70f97cb4b5da7cfb35da64897ce69f96ffbecacfe64364ce220b74d075", size = 12257, upload-time = "2026-06-19T16:07:58.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c7/9215dab638d28aaa2af87b66324b954f53dd78060e0387f9300710332e4e/pyobjc_framework_contacts-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:536a46a5a55040142a2cba108ac48045f6da266a042f2fa0ec2bf4b7f8bc1e34", size = 12413, upload-time = "2026-06-19T16:07:59.544Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-contactsui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-contacts" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/22/a01e677c4e44c3e03850c7765b4cc20e3b8fbad53ee92300eddd77dc8627/pyobjc_framework_contactsui-12.2.1.tar.gz", hash = "sha256:6ddfaf3d3f159bc4bb8ccd65414e94b4b6539a5588e84efb01838b19e3b1ba0b", size = 19329, upload-time = "2026-06-19T16:20:09.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/53/deaff064fd9e4ec7996e9e218ebc9ed60f9ba00e18b30e85b5cbcc1eeb65/pyobjc_framework_contactsui-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:92fcf91334dbad85da45d66b12e8ff9105e3ba6a204b07342463318f31758fb9", size = 7890, upload-time = "2026-06-19T16:08:01.353Z" },
+    { url = "https://files.pythonhosted.org/packages/73/1a/bbcf4c5a21ff5aeb93cec6f629fd9e4fc7806fa03d11711346449b0147ea/pyobjc_framework_contactsui-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1a447f3143759dc545a0a8caf23b3f6b5d4a27d50451046093a01f478a81bd8b", size = 7913, upload-time = "2026-06-19T16:08:02.133Z" },
+    { url = "https://files.pythonhosted.org/packages/05/16/617d8075fe65d3b27b5140da604531bb343f55eaa676ab88208d9c4e2ffa/pyobjc_framework_contactsui-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1cbdefbc77830205ca9e63360cad08562d7b97789a792e98ab2108c018f10768", size = 7926, upload-time = "2026-06-19T16:08:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2d/15210bf2f5b5b57b436231c7789239cdbfeca4ad82a0b2f41d1a55256a81/pyobjc_framework_contactsui-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:78452b5171a32d206a13d46ab7fdae60d87dd49802f531ced8646e6c71c25c57", size = 8073, upload-time = "2026-06-19T16:08:03.778Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/98/f0be6434e55627f843c253791d3fbeaae4badc03c07a2ad1cb06b4e698db/pyobjc_framework_contactsui-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:61d2a2df53a8bbdeadc552684a556c6ff7d4537c73333aa5629274eda2b99508", size = 7983, upload-time = "2026-06-19T16:08:04.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/eb/647e6261abb93b15515627f618f88c03b412c59bd1b1ed608906743567ab/pyobjc_framework_contactsui-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:81684620b41bedcef5423ea84337acd2e874c7ab7c2328b2f4f8d5df70daaffd", size = 8135, upload-time = "2026-06-19T16:08:05.586Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e4/5e11e387a598fe670e0f0db1eb73d84f096bb2c5ce12f576477651649b36/pyobjc_framework_contactsui-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3ecfb26a90b0b99231f433775ecda78bc461833e80212f8aa7f4f5d33dd1fe40", size = 7983, upload-time = "2026-06-19T16:08:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d9/fd4086be33ea326205847d2991e94e1e6b236183d69bd66cfacc3957d603/pyobjc_framework_contactsui-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:26acfebc03d264ff938da39ef33dbd1e09ab2c422245d146f14aafca78189894", size = 8127, upload-time = "2026-06-19T16:08:07.735Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreaudio"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/df/f1d402bb7b437374f942bb19410a955a74291867c77a920d9c13887d9e48/pyobjc_framework_coreaudio-12.2.1.tar.gz", hash = "sha256:7dfbf1851523aed453af43a628e057d8950d6e020574aa497a2e4f559b6383c8", size = 78690, upload-time = "2026-06-19T16:20:10.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/1f/853c498e18db8b6d9eb0cb2261bf8cda3948f2c925d1c820baaf96fdb54d/pyobjc_framework_coreaudio-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:214ce41d1ac3743377f607326d3ff70494dd6f75b2c575fe9c99d3890c545dee", size = 35149, upload-time = "2026-06-19T16:08:10.278Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c1/1fc7a344ac15646fdf78c91af81028113c87375036e505082cf1f90bd657/pyobjc_framework_coreaudio-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:41a0d8c3b3957f35f17370071aeef94e176d07c9e2130d0aeeb4b260117acd52", size = 35415, upload-time = "2026-06-19T16:08:11.329Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e4/71b2e3bd03f0404c89b432273d272dc5427185fd9ed828036730bfc9d057/pyobjc_framework_coreaudio-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6fb46bc090edcaefeb70be2c179071e7a758e3375aebd3338b11773e371c3dce", size = 35445, upload-time = "2026-06-19T16:08:12.455Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5b/07dc0bf9f79d3b76effba3f0a754be6fda0947848939236820c8e70ac896/pyobjc_framework_coreaudio-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d05e5fd58c1e5f48e7767b1f6182cf36ee9bff38568544d51f468b25ad90e334", size = 38205, upload-time = "2026-06-19T16:08:13.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a4/6495dd34b1ed7a0e8f6d672577da62a92b166a0bc2ded8e55e552cbe5ad2/pyobjc_framework_coreaudio-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:efb79709371f29139f44adc36bd6c32d5a3a0ff3ffd0c5f3f372275cef893b18", size = 36697, upload-time = "2026-06-19T16:08:14.407Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/9e/9f0cba5b973a5c8041edb75cf0870f40324437721428b1baceb437553e3f/pyobjc_framework_coreaudio-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9c06b9d7ee3b2a76dd171de519f571d09bdebd85f40b5960d16f711395513cdd", size = 38300, upload-time = "2026-06-19T16:08:15.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/13/e8df283cdd73dec1b97033be04a89a05e17714c8e2229f2a2e5a44f377c7/pyobjc_framework_coreaudio-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:51be22e4fac73ba4b26ee34c457ac94f56218e4e9c1494f8f4e7dfe9dbb6a15f", size = 36723, upload-time = "2026-06-19T16:08:16.247Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b2/c76ddff169b45d7239468f44bf4af3ff431c014fbf0aa5dbbfcc099672f8/pyobjc_framework_coreaudio-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:18717e6e106556fd4ffd0bdf6a6dae796fc9100c6b373e664437604dd0b9e94d", size = 38333, upload-time = "2026-06-19T16:08:17.264Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreaudiokit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/82/622a58a3aff47cfdad8cc3bf1c6a3a0c4d73d1cc3c71d050ac1bc0a62c6a/pyobjc_framework_coreaudiokit-12.2.1.tar.gz", hash = "sha256:61a5b796f8296ca5cb4779ec19391ad3a37f35c0c689a401d6e8d41cbe936f08", size = 20941, upload-time = "2026-06-19T16:20:11.407Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/41/0121efdb19535aacd8fcb1c03bc7cc6f2e1865fabd77316d33e6422f09ad/pyobjc_framework_coreaudiokit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c36db7e1c6606cd8dc3d50a503f596774d554476729dd5870d05c52aa2de4da1", size = 7273, upload-time = "2026-06-19T16:08:19.111Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/8f/78a68b53ee2227dd22939f8d435b5dc6252228fbcf5bbf497fe0d6a6b3a6/pyobjc_framework_coreaudiokit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fbc5f8f3b46645b1051658be8b172c85ed700a649ba3c4bcf68a5b8d3c09ecee", size = 7300, upload-time = "2026-06-19T16:08:19.882Z" },
+    { url = "https://files.pythonhosted.org/packages/44/46/5018ea6e71c3f29ef63241a28b20f67cec9236776d17a23e2d628171a0f6/pyobjc_framework_coreaudiokit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f6f4a3b5fac21170cce2f7585117c3fcce873ead84b4fe7e294dc823bff242dc", size = 7311, upload-time = "2026-06-19T16:08:20.701Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fa/6ea54d77c2b557c568274ccf75306fff426b7e099a0cd0b7e2c9c28c6e78/pyobjc_framework_coreaudiokit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dbc7d4ef4d7af452ba45c14e5324c11865e170b3b15f35d9431c97431b208f58", size = 7467, upload-time = "2026-06-19T16:08:21.767Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f3/000526a108d242477175cc9cecf71ca951fe6807db7cb2bd27389814892a/pyobjc_framework_coreaudiokit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:90610d5af81a071db7508df7a0dcc06ca2a95602f11dd7205f591bc4690e134f", size = 7373, upload-time = "2026-06-19T16:08:22.582Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/49/bb846c6d2f34d168c24fb7c6968699ec267de0fce6d381fbc4ea6e6b9100/pyobjc_framework_coreaudiokit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f997becd046c41e2da1a4e9f67715a13344f8546364de973dede6bf47a85b798", size = 7530, upload-time = "2026-06-19T16:08:23.398Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e2/84bbd3322eb54a8c85c301ea64be7888b83038f3a83716b17e775af64e68/pyobjc_framework_coreaudiokit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:78673312ebc806c4c635ca5906dab7c109d8346f058159cc6efa2be879244aab", size = 7372, upload-time = "2026-06-19T16:08:24.217Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2e/53817ad60d89043c890b0e8252c99e8d772e7ccc8a938217a8a741114558/pyobjc_framework_coreaudiokit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:173b58fce17e83aee72adeebeb5cc5a994184cabd1d5c25a6e4ba9902ae3e6b6", size = 7525, upload-time = "2026-06-19T16:08:24.99Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corebluetooth"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/91/c76f3c5e8e80c7047e43c4c05b3e6fda9a7cefad5aae85487007674c966c/pyobjc_framework_corebluetooth-12.2.1.tar.gz", hash = "sha256:7dbb285295097205bebbcb11f55161e5faa02111108fb7b17536176e31971eb0", size = 37568, upload-time = "2026-06-19T16:20:12.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/ad/de57d9060e4c5e9ca1a9bdd5b6bd1bdb73b198c0c53953cac445d9b3a84b/pyobjc_framework_corebluetooth-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f11df7052fa2d0524a9dadbc9c578fd3b8f3a350431edfa4ffa9e0a74b6faa32", size = 13195, upload-time = "2026-06-19T16:08:26.961Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c4/7938016860850e28c001dc9b7c653352c43f7aebfffc6d3c5fd087281f22/pyobjc_framework_corebluetooth-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2f8d2ed65c0e98ba044b6a7fc2f9a290a5c579a28d33a57c642f8617ccbcca0f", size = 13217, upload-time = "2026-06-19T16:08:27.802Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/79/890a53ed45c1006eedcf60627b7d661c8696e5367723ceb25cc6a0216b30/pyobjc_framework_corebluetooth-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:30a26eef36c250fc14e73335641e24f764b32b7e42bae945a5d8a1c2347040b5", size = 13235, upload-time = "2026-06-19T16:08:28.727Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7a/40ffc3be8e31b1eb1f8f5eb2a58ef832287fb1ea6b3c452dc8b25b9e064b/pyobjc_framework_corebluetooth-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:756933b9ce6160a986c8877ab667659fa2d8e15aff28d0981b5284fbdd1ea735", size = 13416, upload-time = "2026-06-19T16:08:29.643Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ff/6f3b0bb3110ec82dbedaea47de151bd688980f5aadc634ef0cd236fdbd16/pyobjc_framework_corebluetooth-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2a2e6d56f51e4ca3e3b9766ef34150a9a7ce5f0cf4f9ee879ec10923af58e97e", size = 13223, upload-time = "2026-06-19T16:08:30.672Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4c/4e12660569219e4a68186ae9709b85278d3ebaf8d2f8e1c826a7337f4f7a/pyobjc_framework_corebluetooth-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:50d7e4245dbdc8789dcc1f11fca2e633aa126a298b09db62f8216531fe107ee2", size = 13414, upload-time = "2026-06-19T16:08:31.679Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4c/976ae9bcce3615af806e3c314ea9caa3faacf11ec44f00b1a149559c6cb3/pyobjc_framework_corebluetooth-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c8d126c56b71c25218be186930a1b41739f83e931726a52e3298beeb170c5e5b", size = 13222, upload-time = "2026-06-19T16:08:32.481Z" },
+    { url = "https://files.pythonhosted.org/packages/99/be/44bb648a6b5c8aec79138bf562dab9eef414016ee31f37066bf81d809ae9/pyobjc_framework_corebluetooth-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:81023518feb75e9b2b676b28198955c51ae00548cf23c73c524c7101263b68db", size = 13424, upload-time = "2026-06-19T16:08:33.336Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coredata"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/cc/62113edb09c6f72922d800ad7dbd2b812e69f5933a245c59f2d33b214a47/pyobjc_framework_coredata-12.2.1.tar.gz", hash = "sha256:f357447b7955cfe5391dac4fe003b79ded307f4f00712dcfaec3d3ecfca30824", size = 143307, upload-time = "2026-06-19T16:20:13.096Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/b9/ab7be45781781fc68faf523b7cfcdaf05c2b307fbc49140905eb31f3ecf2/pyobjc_framework_coredata-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:382594752f87fba5b6804619507d54ab4b6d2b54b520bfa291b06003e36c4646", size = 16542, upload-time = "2026-06-19T16:08:35.388Z" },
+    { url = "https://files.pythonhosted.org/packages/32/17/87ef5c0edb220df910a4936ad23272f763065ee4817ad01107b19a8c78ff/pyobjc_framework_coredata-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:53093b9a500e82794b142bfe3c844414e46ccc2b2f9e1f5a998243646be59725", size = 16552, upload-time = "2026-06-19T16:08:36.178Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/90/6c0887e8cefd12b76e9c6104dd07a5251ff2d5fe47a27427b07754326d1e/pyobjc_framework_coredata-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a8353dbe4cb0cc6d5313d23e47ed6c00bfc5161c84777d1d3e21048522822feb", size = 16562, upload-time = "2026-06-19T16:08:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/60fa04f65640e76e2b49a2a2e297b54c0d980a2bd631c3e9b5c2d247e262/pyobjc_framework_coredata-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7be973a5f2f5646a64d4c25175ec7ca2584f3ccd2c8bea4c2abc702ca61884c5", size = 16722, upload-time = "2026-06-19T16:08:38.044Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f6/b58d1ee3a6c489e0a0429dcac32b283e6609cba5a8da3cc013cfb03b50db/pyobjc_framework_coredata-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e3f12941b0b83c66c3e7d9845bc14ed8d215c2975f55098deee56e22477b93e5", size = 16624, upload-time = "2026-06-19T16:08:39.068Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/6f/dcdf9ed284f7dc56f48667fb137d1080de371297dbc86103b99b5dda94db/pyobjc_framework_coredata-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:cb6c3b1f70301b2201e84b12adfac93c8f47c7678f35d56ae4f63100dc4e438a", size = 16782, upload-time = "2026-06-19T16:08:40.07Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8b/dafc41f03709426901f5981334ecbd9b315ea29616d64d8711502d8ed802/pyobjc_framework_coredata-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:698b5591c622b6ce451851fe393fe7e9a0a1148830659f500e577d06ea470781", size = 16621, upload-time = "2026-06-19T16:08:40.908Z" },
+    { url = "https://files.pythonhosted.org/packages/14/0d/05ebf0eab33ccc7cc80b7b5e6da89a37efba99aaa0b2f78b5176906f7a9b/pyobjc_framework_coredata-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:dabebe6ac3cdda4563635c781b0ab5e65e4f04e76e636dade0996a58ea66b311", size = 16771, upload-time = "2026-06-19T16:08:42.185Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corehaptics"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/1b/76c27ae0f86126802c7f82f21c67868467795810750d9d192006471aa965/pyobjc_framework_corehaptics-12.2.1.tar.gz", hash = "sha256:73ce1afcb0174add11fd6f05cc67d8a371802ce8e94ba9d4f65c7cee0f392b0f", size = 24886, upload-time = "2026-06-19T16:20:14.011Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/0c/23e82eded054389a686377ebce9b6f82d4fed4c445b004bb8385c3188bb1/pyobjc_framework_corehaptics-12.2.1-py2.py3-none-any.whl", hash = "sha256:d19505e9e38136f50fc551ad0e1849afd1656dce068c82018ad669d01128f8c9", size = 5434, upload-time = "2026-06-19T16:08:43.061Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corelocation"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/93/41d2ae5cf15a27ee1b51e167b538e50aa752597002878556ed49b3615573/pyobjc_framework_corelocation-12.2.1.tar.gz", hash = "sha256:10b3c206049b70cbab0f98b37bcd91ad97de5ab57041b18a60ab702629009a31", size = 60318, upload-time = "2026-06-19T16:20:14.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/75/7a72b5c8cd470eeadc40b9bf05cbabb5049372de0a44ced4a04489d5a165/pyobjc_framework_corelocation-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cc3f7d0a9dd54b99faf7020205b16576466aff70c7babe2a905b8818a0c1d80d", size = 12836, upload-time = "2026-06-19T16:08:44.911Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/4f6a89027995948270699c47a86583bfe586ac0c480cf8427fb708bf3a9c/pyobjc_framework_corelocation-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:683b6eb23db94ae6ca48e58089c4a9641fd90b1137e54c147ad56ed6db4bb570", size = 12857, upload-time = "2026-06-19T16:08:45.738Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/00/156e1d533f3167e638a8e649f02a422cd1f95270932fede56e6bcf46c878/pyobjc_framework_corelocation-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9f336ab0f9289d1909bf86cdd798ac4308166f6e90eecf07452d21182b9a7cba", size = 12874, upload-time = "2026-06-19T16:08:46.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/7519b4f9d4feeebfb770ed563b756c5dd370d9f4fa302425f05829a7d2d6/pyobjc_framework_corelocation-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ca3b36828b4324c058ccc289b33cbdb7986bf879719d99a735c3abcd1ceb6ad1", size = 13004, upload-time = "2026-06-19T16:08:47.482Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/09/556f20c1178bd39ede1b18690211b36c13ad458692330474ef2e42b2202b/pyobjc_framework_corelocation-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:407336ce4e2c4d4d61b486cf64a4672a0048523b9412db8d3a1d1d5b3eaa53bf", size = 12852, upload-time = "2026-06-19T16:08:48.495Z" },
+    { url = "https://files.pythonhosted.org/packages/57/19/bad61b941acf3c7e1a3aa623f9bd71dab9cfa7a52df40f79fed4370c2ddc/pyobjc_framework_corelocation-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:80423af235cfc73a719451e326631e743662d9c03821d227647d9fdb596a6401", size = 13004, upload-time = "2026-06-19T16:08:49.283Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c3/e3b7c6982a053293995be2cb47bc6294f01db98892c3f155f08ec87f9922/pyobjc_framework_corelocation-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8e1a2e5cdf5175b01cdda52a8d7dd5daec0afe08a5a0c7a359c2a2f93b66109f", size = 12839, upload-time = "2026-06-19T16:08:50.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/bb/a3bf2bc14ad5f0b6586de6526a9677cf505654ac1dace6b7aae3935ef72f/pyobjc_framework_corelocation-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:304db40687dd383fc787b795be9e8825f33c4fabf58b9a7d5582377eef173311", size = 12993, upload-time = "2026-06-19T16:08:50.891Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremedia"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/79/f501d730a9c320e0b2b3916e95f57e66dd6736d210a1aa5b63eb6c43e605/pyobjc_framework_coremedia-12.2.1.tar.gz", hash = "sha256:71b45f7cd52bd997d836c15a0e1016db90815a219dc87fd20435a6f08b87df7b", size = 98252, upload-time = "2026-06-19T16:20:15.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/34/8b97b76f0643e01c98d5c246b1ed74884f4b3c43dfff2a36886212e20dfa/pyobjc_framework_coremedia-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:38e03a92a7fdf43162faadf354a8497ae764e3b3be26a8ffb107ed5d743cac76", size = 29513, upload-time = "2026-06-19T16:08:52.69Z" },
+    { url = "https://files.pythonhosted.org/packages/af/17/6bf365530573a6b7719b5a47efe6c38ac8c42f6b556babe419f5de48a84c/pyobjc_framework_coremedia-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fd0e25bc704dd91882bc29d682880c42f712b39bdfe3d3168780d24a9d9eaf26", size = 29419, upload-time = "2026-06-19T16:08:53.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2a/9e5beae2961c9d22ce16258f39edae69996ee0167dd4cfe4e771454086c1/pyobjc_framework_coremedia-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:45878f686ce8ea1735ce382b34ef3a5852cafe0ae2a27a49c08701f4c3ab830b", size = 29431, upload-time = "2026-06-19T16:08:54.41Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/51/00b7f012e55475502296cc8ef276b94ad7d4d10d97ce2e88bf9d87f9b664/pyobjc_framework_coremedia-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9f2b30ef288c9f2fa1599a1cc5868f8cd949c7138a7f15244c7a6884afcef273", size = 29491, upload-time = "2026-06-19T16:08:55.297Z" },
+    { url = "https://files.pythonhosted.org/packages/16/dc/7083e6781fcd843d210ec6d247d28c6e1032ea1c5655b9e1182d0a85f331/pyobjc_framework_coremedia-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:84e9fb3f7b6420fc3865a5812604c63546b5777f4999e0e0e830a9a0816e8743", size = 29468, upload-time = "2026-06-19T16:08:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/11/74/edb3ec87d2e5f962c75af990207e4df39b290f11b4f4c3cc446ee141e4e7/pyobjc_framework_coremedia-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:541d64d2fc7576054bdc3508a94f37671e81e5ca1582e16ebec2c0e05dd75412", size = 29519, upload-time = "2026-06-19T16:08:56.956Z" },
+    { url = "https://files.pythonhosted.org/packages/28/0f/9176b6a7666e46273c0392c8f77bc812e006dc74a1c21263c4bdf385012f/pyobjc_framework_coremedia-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2a355770b66b4caf99560c11af44dfeca53066ece75807fc6a391a16369ccc72", size = 29502, upload-time = "2026-06-19T16:08:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/13e7d8d16528734690f83abd901cbc53dd6f7c1adbcb3a902166735c6c21/pyobjc_framework_coremedia-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5536453ba631227810a1141fb1761149244bd6d0e7cd4b12477be3b164f5bb11", size = 29555, upload-time = "2026-06-19T16:08:58.792Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremediaio"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/8b/60e73d8049e9c123ff237694acea8752e9e8143864bfea4bab0bebb55db4/pyobjc_framework_coremediaio-12.2.1.tar.gz", hash = "sha256:edfd070544857b8e1d2ae55ed7c7eac9f513b4cd7c03ee79615c7d524e362d62", size = 56604, upload-time = "2026-06-19T16:20:16.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/9e/7bd5ca10c31a987b04c18a5b40dd7cb31fa7f13d221b4d209646d2b34c52/pyobjc_framework_coremediaio-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7525dff27f84f7cc007d2077787835cdf094ed925235e4f179bd6558a889b008", size = 17305, upload-time = "2026-06-19T16:09:00.583Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f2/95c8d8ef684b377d70b65ccea9cc8bb583eff79690d77a390fd52f190120/pyobjc_framework_coremediaio-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c60ecc49fa18a53c5bcf7f844554d5e24883d2b7d5537923dfe4e8512069a6a0", size = 17361, upload-time = "2026-06-19T16:09:01.421Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/85/ae2715fe1d788e166ef04d7080f09de5cf3a63fa83253bfde42027ccf089/pyobjc_framework_coremediaio-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:30cfc0e30b46d67668114d7d2bf0a66196928ad84db77d34a1615d3f1b661c46", size = 17324, upload-time = "2026-06-19T16:09:02.234Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/99/96f68d7d82978a568ffed99a8b42361343499af4e227a4f896351418462f/pyobjc_framework_coremediaio-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1dc37de0633e2daff4ae14640cec68e1b2c2d3b11f866f36961704abdfdabc38", size = 17646, upload-time = "2026-06-19T16:09:03.158Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/63/9504851dac16bfd7dccd4ddd0e1aa74d6185861c405213f26fa30df45ac0/pyobjc_framework_coremediaio-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:599dfff52ef5a7886753fef44b1226d939b1f44c02d7a9790fe40e1f792b9b81", size = 17347, upload-time = "2026-06-19T16:09:04.037Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4e/acf08847ee0fec18ccc944682cba5dadf9c0c9f32e9abdea74dcf725cecd/pyobjc_framework_coremediaio-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ae6485b88b13953a6485dd3b9afe6a99b538e3fab3c72c590a943c5173348268", size = 17644, upload-time = "2026-06-19T16:09:04.943Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d4/0c08222049c302d52e65acc89c28118581609bd8a307b02619a862d4ecde/pyobjc_framework_coremediaio-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0cb44d84412d737f103cb06b5b400e376ba8869da0d31326e5d040861831342e", size = 17365, upload-time = "2026-06-19T16:09:05.792Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c0/6e6de289f2126978f462b506faf5df6f13329ad71f9a4d123da34fd06469/pyobjc_framework_coremediaio-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:cb6043694fddba0889861e8321cba422fd3d90f0e95ad716826e67246d86bb96", size = 17649, upload-time = "2026-06-19T16:09:06.638Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremidi"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/77/c51599da17f742fdcaaa381a26daadc22c79739dcf7705f8faf29ca1692a/pyobjc_framework_coremidi-12.2.1.tar.gz", hash = "sha256:d9744001102f935646997136c3d7d0562088bafa1837e5ccc439b5c8ee9e032e", size = 63469, upload-time = "2026-06-19T16:20:17.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/5c/0fd7111ed45d665e9d82d8e03462c2c4e26115a16b1834c3045e1ebaba3e/pyobjc_framework_coremidi-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f8c42d469332e3e1811f69fb0dfbcc9ff5d98e3ee08348ccbcec90bd1bcd8288", size = 24491, upload-time = "2026-06-19T16:09:08.474Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/02/b6d415a946c0b48d555aa96b2e8b11f45965f1f21524d91a40821e60df14/pyobjc_framework_coremidi-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab57adc4104135ae0373781b055ceabd9ac45db48e171502fcce48317b5c8d51", size = 24581, upload-time = "2026-06-19T16:09:09.451Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f9/45acec2ddfaed67da0d1a9fedc954162b899ab4f8612593bbdfdc223345f/pyobjc_framework_coremidi-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b6596d9062221097164f8adb445530aca398f6abee0111178cefe37474ab8d2c", size = 24605, upload-time = "2026-06-19T16:09:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/05/557f0e27db08880e6f403b192dd5e99c6cc68717042b4f28208c6f80901e/pyobjc_framework_coremidi-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:25ad1c67e2e50b67d0569f832ae8531c2a9261a6740a1b88d311fda5211f6130", size = 24757, upload-time = "2026-06-19T16:09:11.436Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/17/3dabcfe3db51d1ad6b91f8b4b0a5dceaa38bea61d5434c75763c28aad936/pyobjc_framework_coremidi-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:05b0da253ee7ebd2bbcc40f2893cd6f78ac50c5da07d256faecc7ef0746fbb7f", size = 24646, upload-time = "2026-06-19T16:09:12.226Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/8624f3598d7539da94fd00a510d6c4273ca6c6a88c613d66fbae2f68bb96/pyobjc_framework_coremidi-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7e76daa635b57659efc30ebb9cffa6e86beacda76a690120183961fcc5cdfada", size = 24810, upload-time = "2026-06-19T16:09:13.648Z" },
+    { url = "https://files.pythonhosted.org/packages/69/26/e3bfb5666ae2c69d5bfdaa7115299f6a0004ac900d020ffb2bb52192c29a/pyobjc_framework_coremidi-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:98fdb11eff3ce6ebc5841b91fadbfcfb5d41dd49bc0f1b4b0f55918e5f6a9959", size = 24638, upload-time = "2026-06-19T16:09:14.704Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b7/887887cdff0e27274bfa1d7b7e99ffe4233ea85cacb3a7f5f00bc709512f/pyobjc_framework_coremidi-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:7cc1e3ac498ddd3cb2424ae003fdb06911c9aaea2e5f4544b14497cb512812f9", size = 24799, upload-time = "2026-06-19T16:09:15.517Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreml"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/1e/7d2db3e4468eb04cc92264be83113d86eea4f96302742437de695a445d6d/pyobjc_framework_coreml-12.2.1.tar.gz", hash = "sha256:ef3c2b6a160891b44173235603d10174929656b9c206d6f2f443fe2aa903c2cb", size = 49272, upload-time = "2026-06-19T16:20:18.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/93/1c5ca6b3cdb32d37b1df64d18d6e38b73ad7cf30b55ff51083093e5c8388/pyobjc_framework_coreml-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:711be8528b0cbbc49b5bd4669309f0ad0de6ed76499ffb706b0dd2f1b294293f", size = 11945, upload-time = "2026-06-19T16:09:17.464Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d9/d639ecf7f5730482c0be4a9a0e340a06d48fecad0976ca708cdfb4b79429/pyobjc_framework_coreml-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ca06f106c8d0e2e818212e6cfe9270bd333983ffd086be7b474fc9df34cbc5cc", size = 11973, upload-time = "2026-06-19T16:09:18.357Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a1/7f361206e202e84cf5695a8d1dc25810e8f58c4b9d043d10c0030a04dafe/pyobjc_framework_coreml-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4c9299321ced92439c203342183fdaa47aa8f125b6ef831c55bcc91a69e196e9", size = 11986, upload-time = "2026-06-19T16:09:19.211Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c4/763f7e8e8c63f4be106046dbca0cce3f33535c07dc5b079734951686dbd7/pyobjc_framework_coreml-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1ff65a16661abcc7c2dfe90e87b821d596bc17d1fed44c3a7ba36bd60b002a99", size = 12213, upload-time = "2026-06-19T16:09:19.991Z" },
+    { url = "https://files.pythonhosted.org/packages/09/77/957af9b9afcb8de21cbc3e0b58f29c28bbfa6b560643e1de0fa259a39092/pyobjc_framework_coreml-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:554b423411890d26a03628bb43f848d45656980b4cd43e8f91f84b52347f0b66", size = 12028, upload-time = "2026-06-19T16:09:20.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4c/10bf963e3dabd5354e64697b7ae847586169c37638da645f3af33165231a/pyobjc_framework_coreml-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6e2d71048e80c27c7c0fdd01b9ec5d309c873cb2c4da64578f13d842298a9186", size = 12207, upload-time = "2026-06-19T16:09:21.612Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ce/2c00c20db21112955aecc3b673da804734201a62bd9ba53e4d47b90acb83/pyobjc_framework_coreml-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:52dbdd00da500253ed8b21193ee0a4ba5c45e155fbe0d64448ba2c6666552f36", size = 12029, upload-time = "2026-06-19T16:09:22.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/53/d0401ecbbab4729b0b5a9a4eb8dd1a9bd40455ddacbae8dbc2aedb332286/pyobjc_framework_coreml-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d1cda08f258e30f5c92925d377a35bf5cd4a244911a4fb2196505431d2462ed8", size = 12198, upload-time = "2026-06-19T16:09:23.3Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremotion"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d5/15d318ab0d12681ff5aa5c6799287480dff561e2b3a79d2befe1811b0453/pyobjc_framework_coremotion-12.2.1.tar.gz", hash = "sha256:21fd319d7313b9b03f062239f1c09e324969d5da0fe74842c92a2724381bf78e", size = 38049, upload-time = "2026-06-19T16:20:19.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/58afe54cdecca3715f3cb1cba9d340c9ff24d24b46b032bee9c21112fef8/pyobjc_framework_coremotion-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:71a33f6e33b47c132178bd7bcf8fdc0ff2e7dbc66bb0db01ec2bcc322910eb66", size = 10439, upload-time = "2026-06-19T16:09:25.249Z" },
+    { url = "https://files.pythonhosted.org/packages/58/28/a83a7ca091022d8b3df7ba1af2ad98b683f9db5c9e393e200c308a30f87e/pyobjc_framework_coremotion-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:05388142cc892b95e40fb626748a4af0816b285bf33f1fb3b8a856b964581433", size = 10456, upload-time = "2026-06-19T16:09:26.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/3f8e52e418be615aeb170541f873af739e756aab7d3610d707bfceb48698/pyobjc_framework_coremotion-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d18a90639934e0d4379cc6e632095cda1287c03054be73d79cb3eb680909445a", size = 10470, upload-time = "2026-06-19T16:09:26.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0b/6c69a4eae1e6ef0de4afae1cbef99e45348b1dbc067648872da9a6903b44/pyobjc_framework_coremotion-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:848aa8c0d0af9beb909f28f7aa6555b62646ff34a73873f8820d330c3c3e5578", size = 10616, upload-time = "2026-06-19T16:09:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/64d30e500aa92ed5cf97f63ce742615eea312dd1d790959c5f609a4492a8/pyobjc_framework_coremotion-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0caa15ddd0a25ed2cff27b28918ec690e1031ad62db8af5c4b0ec1957448aa10", size = 10534, upload-time = "2026-06-19T16:09:28.432Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b3/73b5e6bd8319d506a8effe250349c346f7e429bbd55d44f84fbcdcf05959/pyobjc_framework_coremotion-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7596619951228890658833c6a7bbd50b7287b501feae31d774cf7e699e9f8f9e", size = 10687, upload-time = "2026-06-19T16:09:29.443Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d2/f84d404430b905c6630db22f6cc768940e602db7ac7f4297a429546290a0/pyobjc_framework_coremotion-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6ccbc65ed88f23f0824dac41a321558dedd8ddacb3b6c967d19801c5418a7811", size = 10523, upload-time = "2026-06-19T16:09:30.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b1/05c42f264e2d01d483ff80b936f99ebaaf195ae081b6369a597f2db82a74/pyobjc_framework_coremotion-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0acd45e02a10a8e7f3fc6b2829740c9c18fc4c2adddf263e117a97c46105222a", size = 10684, upload-time = "2026-06-19T16:09:31.189Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-fsevents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/dd/d87ebbb99b1c277a519e1b7e0fb5efaf2e68833322d9c1eca5ecd79ed8b9/pyobjc_framework_coreservices-12.2.1.tar.gz", hash = "sha256:b4f052acd7346afa6f5441d32a19faaf080c3441cfaafad40c9b9a485b664554", size = 399935, upload-time = "2026-06-19T16:20:20.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/d8/0020ace0ab37bc81f865eaa6f5b2f7a27f5389a6179d6e231e647dd17f37/pyobjc_framework_coreservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ceec41060d4027c935069f109f85de5e5025cf9b78e5f141b9c29f797396a144", size = 30333, upload-time = "2026-06-19T16:09:33.075Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/46/21129f921528551b8aec853ebe9f21edad01bd7f4501743d0601b7ac7ccb/pyobjc_framework_coreservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cf31f1d6e477414b7c5bd831df5864744a558eec5b055155fe6929ef1070d371", size = 30342, upload-time = "2026-06-19T16:09:33.961Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ad/aa9aea470acd79e69cac8dc561844236db307d6e93ad0e0140beed646f4d/pyobjc_framework_coreservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b911d08cf4e9fab5fd0992dc525bec02cc925102a42b2bdd4b77dd6a7b8ce70d", size = 30359, upload-time = "2026-06-19T16:09:34.884Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0b/67db0cd511e487a847e6ddf1a9e78baf5db210b848e48f782ad15e302b1f/pyobjc_framework_coreservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:aad43d280da1ba8f7a815de1935957f3f61b80eda15c5cac35cdf6a1b20f69ee", size = 30369, upload-time = "2026-06-19T16:09:35.701Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ff/197681804de3504b66971f99d140e3284a028b3393e68130df928410804d/pyobjc_framework_coreservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:cbb369619aefb556f0a0d06fd667ebb2ac4235fb2bb453454dda1571801e259c", size = 30382, upload-time = "2026-06-19T16:09:36.718Z" },
+    { url = "https://files.pythonhosted.org/packages/91/36/b07713ead8fcafd7279d6893822374f99690982dc47f23fe3d3b3d5628ed/pyobjc_framework_coreservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:38fdc91789137af9e22a7bcea0ecdcb9d1d35ebb1c66c58af91973bf9727dcfc", size = 30402, upload-time = "2026-06-19T16:09:37.641Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/bd/c0b88cba4b0cda2390d299cbfe3352b81e7861b46a0a5cb4471081fb1796/pyobjc_framework_coreservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:628aa9ed4c1da2bc2d155b29609de2ac6197bbe41d7f8eb0a594fb2d5d6570dd", size = 30412, upload-time = "2026-06-19T16:09:38.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ce/222b2ec4cfc803e47fe170d04f89d50a397020ca7436582a2d880779174e/pyobjc_framework_coreservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d87eb0f15224925d860c8332cf579b998db850cf0d4f7a611872915bf9271bfc", size = 30423, upload-time = "2026-06-19T16:09:39.593Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corespotlight"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/89479d419712deef7e245a8284edfebc418297a17e3066a990ae88c3bf3d/pyobjc_framework_corespotlight-12.2.1.tar.gz", hash = "sha256:85d6080ff2f3a02593650eeb799d667be66383e8cd947abfec5e8ef8fd10d18b", size = 45685, upload-time = "2026-06-19T16:20:21.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/2d/b9806f21d2bf98429bd7a4cb49f68352459d3333fe58fa30a24bf2a00f09/pyobjc_framework_corespotlight-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d5f9202b197d3863ac163a7b5eb3def8cea1bd58a7b7c930d53824300044be0e", size = 10004, upload-time = "2026-06-19T16:09:41.432Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/20/d6d9d96b4dba80f4030f6a94a322ef8dc384cf26e7a64f63b44d046f3b3e/pyobjc_framework_corespotlight-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:09b40a5982ca77c4b7119cb69765de4f7f565721bd3bfc724cfa9703abf15dc3", size = 10030, upload-time = "2026-06-19T16:09:42.158Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0d/8390925cdd196a209ec2e11b0924060d6a0b12256084bf193107792e45ee/pyobjc_framework_corespotlight-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:76b6315e724f81d62af09673b78ae4e3370b58b8ed639a1a9d2dcb2621a044b2", size = 10043, upload-time = "2026-06-19T16:09:43.011Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2a/3b85888fefe9dd61c6c3ea264950b80ac17ff9a740cfffa4bf796e3174b1/pyobjc_framework_corespotlight-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3591127a7958299406f592027de570d5c8b6eb40a7a0667b912562a42007e67a", size = 10187, upload-time = "2026-06-19T16:09:43.829Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fb/783c1776f81a491065e42622c7d2a80982ba8e852c9bfc804e51e57b7c44/pyobjc_framework_corespotlight-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:154fe491f217eb0e107ba37403b1856263f288ed801b10ede193df427cf15c57", size = 10102, upload-time = "2026-06-19T16:09:45.324Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/0e/dd272a9d0b6202cc039584e2e50a887237a8a06a7575257e426cad517e96/pyobjc_framework_corespotlight-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0da2cb26b9449cfe7f629c4f241319b2eaf083643e63125bda38135943132b4d", size = 10245, upload-time = "2026-06-19T16:09:46.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/7e/a51ca1c2499e1905cd2f094e8d3fa295bf64e638bd15c8c0b782e166dde8/pyobjc_framework_corespotlight-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:53e8ab09ee1e4a2c0e20daf43a782ca381379ec5ee30224c561c62a3acd59766", size = 10098, upload-time = "2026-06-19T16:09:47.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/94/43a3f32026ddf215ff798bb5cbb5f4f251ba8f9b31759a07f10009aa51a9/pyobjc_framework_corespotlight-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:98ba3d15bcb028bd44425f1910c29c92245b69218cd340e8e35eaef535d609a9", size = 10240, upload-time = "2026-06-19T16:09:47.969Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coretext"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/9c/4c7f452059dc1d3845b8e627b9113c247a997b9b07518e848c2ab7ff3149/pyobjc_framework_coretext-12.2.1.tar.gz", hash = "sha256:af740e784d7c592c34025ec7165f4f6c1a69b5a2d9075f06e41e4f77c212aed2", size = 97349, upload-time = "2026-06-19T16:20:22.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/53/c262cf5052c648c48b3f7562fcce188fb78ff94e44cf1c48fdfc62fdfcce/pyobjc_framework_coretext-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:02a448675d28005fdb88fb3c585572b02871e9e5d4d08f88334ec937ea5de6e7", size = 30022, upload-time = "2026-06-19T16:09:50.37Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/11/c1298c2ec3b0cd19a457a1fd0da47898f894a13df5516f80dc04d1a7a4d9/pyobjc_framework_coretext-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ac2ead13dfa4379a1566129d0e8a8ea778a2bcac9ac360a583360fd4f1ba39c6", size = 30123, upload-time = "2026-06-19T16:09:51.183Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8c/154e8f34923b24aade64a20eca2b759f8f67e109654308103080751f246f/pyobjc_framework_coretext-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5c5a3c6e2d905a17efb15572dad97ce582feeab5c3b92537015445e0e0bb46de", size = 30116, upload-time = "2026-06-19T16:09:52.219Z" },
+    { url = "https://files.pythonhosted.org/packages/01/61/f53458c8f7fe74008e342946eca1fa82b777b284d4e13d8bd2e3e5724cab/pyobjc_framework_coretext-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5c979058c77df8cd3dac5fd7db4c484f9886fbe09e2687bfaf269a856f631f78", size = 30659, upload-time = "2026-06-19T16:09:53.034Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d8/d1178bb1ba3bb7a0d7a55db460aa89f2a8b232ed7eaf76cb402923cacf2d/pyobjc_framework_coretext-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d0b3b0467a23dbc2a39d0839e7100cc98b429fb7d52a471bd65477f46bb4c9e5", size = 30100, upload-time = "2026-06-19T16:09:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c3/780d739909e6d8ddd9e8786fd19e8ea10ccfcc7275df987e349af0fb33b1/pyobjc_framework_coretext-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3d4a92fa657180cd0e900b98535da4f0f4d8c76a7077730a507e50d52d2853e3", size = 30642, upload-time = "2026-06-19T16:09:54.736Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/867197c6cf2396b33e95d6175d7fdc6f789314859fb107560ae9b19c7b14/pyobjc_framework_coretext-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:7a17034fd0a08cf58323b7234a385ce0ec355509d414df69e3f8f88df26de1fc", size = 30098, upload-time = "2026-06-19T16:09:55.679Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a3/f4e6d1a38cd4db8a1275eddb287f3cdc2c01c48f80b30e89cc58cfd92156/pyobjc_framework_coretext-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:28980144af75598654f6997b2bbb427885f4f5df90aa4d840f452ba5778ab155", size = 30669, upload-time = "2026-06-19T16:09:56.521Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corewlan"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/4c/1ff3c5042ee2e8344b47978458af62a81ccc49894039fcfdf81d3ced4ee9/pyobjc_framework_corewlan-12.2.1.tar.gz", hash = "sha256:9a7ae402a55710392570a736a2bbe15f372325f941fb7074e682f75e4866c3fe", size = 35515, upload-time = "2026-06-19T16:20:23.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/66/7cc21bf2488373081ee8cfbeeaf7b371946bbbd8b6eb290d4e50d2f13e31/pyobjc_framework_corewlan-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2bd1d9aca137990eb8120725962091eb03e5604c8d3431915127826790356ec3", size = 9996, upload-time = "2026-06-19T16:09:58.296Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/7f8b6da97b41155cab6bbf3a6d611f9c0ad172fd790bc912cb76146a4557/pyobjc_framework_corewlan-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a7a980cd8eb5f879923afbe92bf088e585968b3cd3448b9f4a16d5158b59e6ec", size = 10014, upload-time = "2026-06-19T16:09:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ad/1624d1d8d238cd7aa34b29154cd3d2ab7176c25aa84cbec9b85256de339e/pyobjc_framework_corewlan-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6c9597a5d8b9c7c9b01c28fc6fc6ccc4ec7ea2de83296d5f3f950fbd9c39b448", size = 10026, upload-time = "2026-06-19T16:09:59.849Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a9/f595af68e8975cef88088d963837eb37fb70aa8d1d42f3e42a62cf6c5e59/pyobjc_framework_corewlan-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8d91fd2396ddf71c8df01e36fc9b49a87a63de77220b39eb858f955cc2ebd593", size = 10174, upload-time = "2026-06-19T16:10:00.679Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6b/35dbc6e121fcda3d86db0722136cd48a93acf58d1b4c8058879f9f300b68/pyobjc_framework_corewlan-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e4ac75fcb3a8533c6e65d21871aef8ac52db4e322d038bfc38183667bae6b8ec", size = 10066, upload-time = "2026-06-19T16:10:01.622Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/45/8688ff8141220b64242e03f0619512593d2c3858e7bd852fbad6b14ba3ec/pyobjc_framework_corewlan-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7be48cb7492740d33c3cdfd3e42e527ec2d8feb9ff67f082471e4b2db636e140", size = 10218, upload-time = "2026-06-19T16:10:02.404Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4e/6d8b1530e5735482dc0e9f0cdf0d9371160313ca9f25a16cecf79d885ddc/pyobjc_framework_corewlan-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:ea678d0a91bc5db8a3b80cebf016631883e7e8b0b2ac8b9cdddc97adc7031fa5", size = 10063, upload-time = "2026-06-19T16:10:03.172Z" },
+    { url = "https://files.pythonhosted.org/packages/be/5e/de7068bdfde55839959479ec69b2188867b71979469a894c66a309fededc/pyobjc_framework_corewlan-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:85016f24b0a0e4ea538f74203e22371aecde961d8f849883096576245afb94c4", size = 10216, upload-time = "2026-06-19T16:10:04.575Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cryptotokenkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/0f/697f89ccc2b4f6186b126d29d33def5d699ded72746c6c963aae2f8f4107/pyobjc_framework_cryptotokenkit-12.2.1.tar.gz", hash = "sha256:f5ad2a333ff4ba77d2ba901257836b13c1c93e62342dc092fe57dd67a97ceee7", size = 38273, upload-time = "2026-06-19T16:20:24.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/a0/4bb5e91f1ae45fa02883769bcdc54546729ec8931d2392a4db0e02273d20/pyobjc_framework_cryptotokenkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60ab58babe44175a17aca22f49a2a4d18c24ec0987b1cbf68b5cd1a627e26830", size = 12689, upload-time = "2026-06-19T16:10:06.724Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/cbae3352cd1e68373e65b3cd110aadf3839d2b64c75e639f37b6b954b0c7/pyobjc_framework_cryptotokenkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bd2084fc176f32f5900a17da4d3b05c9563e43521c5df3c8563caef1ebb9f194", size = 12727, upload-time = "2026-06-19T16:10:07.62Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fe/211725952ed459efd0e29e40de11277e1102fd9280f6cf15270de939234f/pyobjc_framework_cryptotokenkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ad53981b7f6d0f8114579c7b93b46fd8ead341663df9ccd845f79633f66b4c79", size = 12740, upload-time = "2026-06-19T16:10:08.466Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/03/a30266392021c8f0f4b8ba64ee3839e051448397d413bcf8ec4e3ba314a2/pyobjc_framework_cryptotokenkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7177828df64d96737d523a5b2ec28d5d5b171dcc1045c486b1e460234519244f", size = 12926, upload-time = "2026-06-19T16:10:09.798Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/79/47e48de94096025f06650286c2ce77c8d360d07075dfc0b10e9b5f0eec76/pyobjc_framework_cryptotokenkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:91fe788acab20a8066f05062410193952cb249d0d0acbbe675f08caf6f4993f7", size = 12718, upload-time = "2026-06-19T16:10:10.79Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/31/41c61fc4f085e94084d19b831057eaec59a14513c02ec313cd0a75fe8b42/pyobjc_framework_cryptotokenkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b5db6a890938f049c977d6a62f4db167c80a3146f753e98e67796ce6a49c5809", size = 12920, upload-time = "2026-06-19T16:10:11.844Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c1/7f04f571f3ba8e240e13155179d021b0c38432189ef9b07e26d751951244/pyobjc_framework_cryptotokenkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2e4306ffe83327219910d72e3c2524d4a6e4a02d64f39bf7b31a3613903b5e70", size = 12705, upload-time = "2026-06-19T16:10:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/00/87/a2e5f0cc0407e13ae2468eb8b555ccc6e2cd2643e917300399f620899c4a/pyobjc_framework_cryptotokenkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:8914647c0556f61a0330b8becf5e42a5c23107f8fbf6acb10f51c0d0b68f3e6f", size = 12916, upload-time = "2026-06-19T16:10:13.599Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-datadetection"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/f2/8c2ab85d3dc8022450af30d58b225bfd3e01693f50d383c80e7a905bcd81/pyobjc_framework_datadetection-12.2.1.tar.gz", hash = "sha256:b1059f9bcfab5a96606dfdde663f41dd8c23a33f8bc8c00371d68796476981cc", size = 12679, upload-time = "2026-06-19T16:20:25.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/fe/4eafd52ca2dedd34b564d7f4cc41da8ef8c071b3fb30e9e74faca1c77a3d/pyobjc_framework_datadetection-12.2.1-py2.py3-none-any.whl", hash = "sha256:c18b746a420e33d13689cbe64635249c492d3b58044089c5c8d6366b7bb46ed4", size = 3547, upload-time = "2026-06-19T16:10:14.839Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-devicecheck"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/c6/9784a80bf3bbd45b4982d9349280938bf70a0b7e15bccc8302ebf324c379/pyobjc_framework_devicecheck-12.2.1.tar.gz", hash = "sha256:f67a745b89cd2f3e307cabee018a509aff0561e3f747eb4dbfe84498f7f2ca90", size = 13321, upload-time = "2026-06-19T16:20:26.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/d5/79ee42be90a01fb0c6ae80b96bdc28160ca0fb415595438f503efe2502c0/pyobjc_framework_devicecheck-12.2.1-py2.py3-none-any.whl", hash = "sha256:085c91137b1583bcd62787a2788adc7a51b24d8c61fb7848fb607ce3bc49553f", size = 3708, upload-time = "2026-06-19T16:10:15.92Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-devicediscoveryextension"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/af/e5794d11e3e485c194f26563d04bcd4d729335ac221547e6d93109dd070c/pyobjc_framework_devicediscoveryextension-12.2.1.tar.gz", hash = "sha256:ccec236e790304c0bb880035b7f14738346c90d18cc4cb77b35169aa1035051e", size = 15767, upload-time = "2026-06-19T16:20:26.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/00/cf5ff4cb4a2c35b7e42e386dfaf7d7692410126c0643db29afa3b028c0a6/pyobjc_framework_devicediscoveryextension-12.2.1-py2.py3-none-any.whl", hash = "sha256:6e4dcee2810968bf1b076d3718ce037f65d770533534806866ad8391f9806bfb", size = 4346, upload-time = "2026-06-19T16:10:17.071Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-dictionaryservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/2d/0c9cc7065a9d2d387be065ad3721b77876627541beee224bf86639c65f61/pyobjc_framework_dictionaryservices-12.2.1.tar.gz", hash = "sha256:631560760d58fe89af8332adee6dcaee35867cf13f4607f7b5c36e85fa4c1db9", size = 10712, upload-time = "2026-06-19T16:20:27.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/72/5a2edb46e216df811e73aa08c22f31aaa5209479a58941c1946bd0be92d7/pyobjc_framework_dictionaryservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:2b9d3d09fc085d913f670e3069b6a88d35b76a03a5f37ce8636b47382dbb028d", size = 3956, upload-time = "2026-06-19T16:10:18.12Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-discrecording"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/ec/a7be70eb1c6700f446c68530e74bd71e9fde6ca2a5e76b237bae8fa980f1/pyobjc_framework_discrecording-12.2.1.tar.gz", hash = "sha256:2616daba51f50b8c6989d38d502ca98ed3ce53aee6b01c9457534267cbb1a4e2", size = 62013, upload-time = "2026-06-19T16:20:28.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/c0/83243a210288fb2a613b5a43602fe6baab6f94584d8ab66fe241325e469c/pyobjc_framework_discrecording-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b589f3aca1bc9dfb07ce9743b2a97ae4f0d0b6b5fc7f01fc5386db580b92e4cd", size = 14564, upload-time = "2026-06-19T16:10:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/23/68/4260e1493cd661f900cc4966a055f82cc9fbba7e311fae5c42190106d258/pyobjc_framework_discrecording-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed929553896338cc0e5109c9b67c121dee2049e62735de94522795708d1b61e6", size = 14589, upload-time = "2026-06-19T16:10:21.373Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/76/207c9f94d956c40a19547456e8d301fbe21dbcc0df69944339960051623a/pyobjc_framework_discrecording-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f6a590c94c53d6d0975b54218cf018f9660f145fe686992d377fbd7b9861706", size = 14591, upload-time = "2026-06-19T16:10:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ea/e5b722dd0daa4bb7c015d41e6c3e6f7013cd757bf27e18134f7954ae72ce/pyobjc_framework_discrecording-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc5557015d2df515bfc75e96b287d1209b59afa2ce1a4566af32e9b8b49e2318", size = 14765, upload-time = "2026-06-19T16:10:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/87/e06f86a6ac77d0896ca2944ab7f7ac88ba26e26d9a71bbe64f4d55a6107c/pyobjc_framework_discrecording-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439fc5b5b930ae7246c06a053748cdd0962db377d1493dd9fbec130939ff4a19", size = 14655, upload-time = "2026-06-19T16:10:25.061Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/04f04fa4071d44d5caf367c8586266083097d541118d3c39a5ec44161604/pyobjc_framework_discrecording-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5e0ad242013ed977c12a69beaef66b7c8e3cf24af5f802261da8241205ef15cf", size = 14827, upload-time = "2026-06-19T16:10:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1d/709d072496482c9d568009e69f41c46818a16f4f18b42ffd50a89e48c53f/pyobjc_framework_discrecording-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:43bb79f284648b07187ce01b3e6b55b1271951b438eb99eea9fcf39c008a80c6", size = 14656, upload-time = "2026-06-19T16:10:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3a/8f96d7d0fb19411141f1c0e03ce1c2f2f9141b41ab31f299beb97d9b46e3/pyobjc_framework_discrecording-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:18a68340d2090a707620f82038d68edd800f5d7806d566605e80104d12068dd5", size = 14821, upload-time = "2026-06-19T16:10:27.57Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-discrecordingui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-discrecording" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/34/be343e4da6765228d1b6c6ac72a0c1c339ed8da931fa2701f28467c14aaa/pyobjc_framework_discrecordingui-12.2.1.tar.gz", hash = "sha256:1cf9e9e028c619f932ecf3ec0efc91227840bf6c6492c788cde91dc5c3744da6", size = 19538, upload-time = "2026-06-19T16:20:29.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/fa/5447695b7b646242b4f0e790b382c4432cc6e730152a19271896e4683a63/pyobjc_framework_discrecordingui-12.2.1-py2.py3-none-any.whl", hash = "sha256:a29bf02898481e6ee02a38ae932a35b9c6a4f68fe9c890504db18e94d15cfa45", size = 4723, upload-time = "2026-06-19T16:10:28.438Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-diskarbitration"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/25/d6a3231f7d81903e6cd6dd9674ef798d45dba2cf301dfb2224277e89c62f/pyobjc_framework_diskarbitration-12.2.1.tar.gz", hash = "sha256:b79a44c8a7791109371bb6aa78ee970c7cf0ee6a6ecdaf92ae3b9dcc4f57f469", size = 18174, upload-time = "2026-06-19T16:20:29.842Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/7e/c95163c4850fcd59f4d761ed0e453c50ab782914df478f53d402dd424314/pyobjc_framework_diskarbitration-12.2.1-py2.py3-none-any.whl", hash = "sha256:8fdde0943ca7499a246294d678b4f01c3f7c7569da19b029eeb31e4e9f01519c", size = 4914, upload-time = "2026-06-19T16:10:29.349Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-dvdplayback"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/de/281c85dbcde3422af95cb6cf4607abde52612bcaa66850b8c1e630f25152/pyobjc_framework_dvdplayback-12.2.1.tar.gz", hash = "sha256:cc715bce5edceaec078e3b39141a660cb4ca2fbe0afdf133bd2c531c170e45a6", size = 34829, upload-time = "2026-06-19T16:20:30.576Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/6c/ee10385cdd403471b205baf701890b5cb640a9dc357013d8a1801f1d5640/pyobjc_framework_dvdplayback-12.2.1-py2.py3-none-any.whl", hash = "sha256:56d737c2a1ffb1076d280b84906adc8091c055fcf6670367a902f38ea4877367", size = 8266, upload-time = "2026-06-19T16:10:30.25Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-eventkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/94/757c963beb0fb86891c3cd16db56d2e1cf746c24d8256023d6d7f4c83ef7/pyobjc_framework_eventkit-12.2.1.tar.gz", hash = "sha256:2528a61da2fed7d71933d7e5407414176cfcac2e03fdba4633633f0d646c75fa", size = 33775, upload-time = "2026-06-19T16:20:31.384Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/cf/504f2531b02010857df765ecebf41097fbd0bf1b803be47afec574199437/pyobjc_framework_eventkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:8efb71afaf9a97450ba701a6fee7de79e0cdefe6d71b5f6724e87b2fd68c5bd4", size = 6952, upload-time = "2026-06-19T16:10:31.307Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-exceptionhandling"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/59/ef544e804de32c5e437b9936742ae2bfdb6873ee1b284609a70e98855220/pyobjc_framework_exceptionhandling-12.2.1.tar.gz", hash = "sha256:aef051e1afda09853289f66d4e6c1b58cd924656afc2a1bec05b15e22e20e5f1", size = 17174, upload-time = "2026-06-19T16:20:32.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/46/f271631363bf830d520ed52bc0c5257cfcfe196859ab1b58720b023ae17d/pyobjc_framework_exceptionhandling-12.2.1-py2.py3-none-any.whl", hash = "sha256:b1d33ccb5ded605f2c92240c5719b64c45505f4c0dbc42b7d8595223b395540c", size = 7138, upload-time = "2026-06-19T16:10:32.352Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-executionpolicy"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/9e/c6f4962416713ee46ae5104b08091d3c1ff49fdcb69bf1edc03d2285b7e2/pyobjc_framework_executionpolicy-12.2.1.tar.gz", hash = "sha256:898d38b19e805e12da317930474f49a9f944f7e2335a9dc9c1644ecdd079d12e", size = 13043, upload-time = "2026-06-19T16:20:32.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/a4/7557a818158c59ed531ce0abbe7bfa8071c8657734b376dcf08a1bd54fc3/pyobjc_framework_executionpolicy-12.2.1-py2.py3-none-any.whl", hash = "sha256:493340d7311f6294feb93327c75675fff24859ad9bb3b87c0ce8d339850c4c93", size = 3798, upload-time = "2026-06-19T16:10:33.329Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-extensionkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/f3/51d50e7af4958d597d924fab765725746ed164ff02e59928296574f6e2d2/pyobjc_framework_extensionkit-12.2.1.tar.gz", hash = "sha256:9b8dea5867436ecfeefc7edb4cd8358c8e7741d31693047f1321e15dfc533540", size = 19239, upload-time = "2026-06-19T16:20:33.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/35/13c03829d2f8b70869da847d27552f0ff08c6b9431c0e58f02ca7ff3dcac/pyobjc_framework_extensionkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:047ebbbfdd61369dc8796a5754cc9b3a50104ccae1d4392f48d8f73ee9b6f859", size = 7941, upload-time = "2026-06-19T16:10:35.104Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d2/f859740c55b569857a2f969a39177fcceb64d41fc345fe39c7d27d48d3cf/pyobjc_framework_extensionkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9279dbc7e75f28b9b6553d351e48475fbf3841f9a30f4b503fe03e18c0ccb074", size = 7955, upload-time = "2026-06-19T16:10:36.008Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/18/c4162af7b93d92b0d6806bdbcfd16cbf0f3e5d6ff17e80b5feea4e0a2429/pyobjc_framework_extensionkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e29f5860aa6acb53582c2742e477922067b959046c1998ed7fd962898fd78855", size = 7970, upload-time = "2026-06-19T16:10:37.038Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4c/472391557a3ff3f3e4fcfb683c34c7f3bf9abef7c8d0eff563cb11168cbb/pyobjc_framework_extensionkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b8dae4aa09e327a44b12c2e5c49250e3439fd98fd8eabd08ae97d4b71180aee2", size = 8108, upload-time = "2026-06-19T16:10:38.033Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bc/89c590272ea844576f17bf52f46de5d6d9be06236be1c79b754e2847baf9/pyobjc_framework_extensionkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:cb00d24a9a3b2284f9f5bdd2b65ca1e25f5743012e728b751109d66f28efb3c5", size = 8036, upload-time = "2026-06-19T16:10:38.899Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/4165f128867f83d4992aa3c7841826c98ea2142e115d7866580be70df59d/pyobjc_framework_extensionkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1307a42439c28e55081e47729dc04ec1de33693fb13df38381914b849580fa51", size = 8169, upload-time = "2026-06-19T16:10:39.899Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3a/68002c7bf2a8b0392af0d777510c3e7b754294f1b8e24b615547cf11bdb9/pyobjc_framework_extensionkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3599ba37400750fbca5a3500c7ecdf19f0df30182c9e9e50a51c0c0e12ee5cb5", size = 8024, upload-time = "2026-06-19T16:10:40.82Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3e/005011c3f7a0bc53dc8ad34b4fdf429a472cd95696023f9f4a87f581f3d1/pyobjc_framework_extensionkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ee7853b036f2a7c52a35ec0d6b155c8c2a36ec6c5bf2e3a35318a8eee66f9564", size = 8165, upload-time = "2026-06-19T16:10:41.745Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-externalaccessory"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/e2/96f79a29c7bc6c229035dd8e92f4f73001affa8e642248cf7ab5bf03b2c8/pyobjc_framework_externalaccessory-12.2.1.tar.gz", hash = "sha256:49658d55b3401c03ef3523ab3b8e2ed082739e971a0070d81b16d06441ac8d03", size = 22011, upload-time = "2026-06-19T16:20:34.554Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/e3/c690f51e505dd826680a3094e9aa511f9d7507bca543e4f4184af23f1d82/pyobjc_framework_externalaccessory-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:787ea43ded7a7f5621cabc3578a7414298dbfd62c73c8418ddceb720c23388de", size = 8931, upload-time = "2026-06-19T16:10:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/42/29/cf69d3931127544a7a576a3c3fa4aede1808ef62ad3c77e3803414aefa68/pyobjc_framework_externalaccessory-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:47635ff739691b8446079b5018c71585dbf33c2d5eff6a34279efb0868caf432", size = 8951, upload-time = "2026-06-19T16:10:44.85Z" },
+    { url = "https://files.pythonhosted.org/packages/21/21/6cc05d60f54f317ab6f0c36d025951ec9ac15cb088b219d88add060051d7/pyobjc_framework_externalaccessory-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c61d2d3ee83d4c0fbe4ef427041fc911c0f168bc7f10f9b7ff9d502e1a9995c8", size = 8966, upload-time = "2026-06-19T16:10:45.619Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5b/c2799931e1c456cf2748c8c81ed9ac8218bc55cf838f4d71d0355f52153f/pyobjc_framework_externalaccessory-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7cdaae96e146ffb1def2b14a0890555e4147ec77924fca241fb2361f93a36b31", size = 9124, upload-time = "2026-06-19T16:10:46.455Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ee/088bed0b691c624e2dbe764f86408b4086748147d63149b08cd28a3eb31e/pyobjc_framework_externalaccessory-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f13955be8d9f6f2e5922600d2063f765fb070bb3b4a2f2c0ef8ec21024d39ece", size = 9019, upload-time = "2026-06-19T16:10:47.241Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/29/8396b3231315a8221a8077805ce57889522037b18e9e5a42a926a6270eaa/pyobjc_framework_externalaccessory-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:16a269b33442580121353739ae128fa0dddd5c59f59705ee57b836932b750ad7", size = 9201, upload-time = "2026-06-19T16:10:48.062Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/19/07379ed2cde32acd29d783e0d76fadc5277f6cb117af934a805004bcd8c1/pyobjc_framework_externalaccessory-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:505ae95af4e8abc67016d26d59d2521b94ba3e6948b849d2cd85069dec31d044", size = 9011, upload-time = "2026-06-19T16:10:48.815Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/1310bfe12885753fa3cc497581441f145cc4ff5efa97d8a16115939c6eeb/pyobjc_framework_externalaccessory-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:d2d3a2dba827c5054832142faec0793ea50e3dd869aa33df54c777a9e03557eb", size = 9186, upload-time = "2026-06-19T16:10:49.601Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fileprovider"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/15/d161117076a478299804b40720c5f110b4540f77ddb1b55e76b18dcc3ea8/pyobjc_framework_fileprovider-12.2.1.tar.gz", hash = "sha256:fd94e8941de50b6bc94ab8fbbf0f4605eca0602e4bd48088b8d6c1162115b506", size = 50576, upload-time = "2026-06-19T16:20:35.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/42/5848410e19ce30a784f30b586d762e1777a50ea74517dfd93a30dc0146cd/pyobjc_framework_fileprovider-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9fe7f23dc7bb3bb0a045ec443ff7a55eaf3e4007b2d9a99a79ff201c9536c58e", size = 21062, upload-time = "2026-06-19T16:10:51.862Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/79/d9b4d70c71f6828a6dd1393fcd2e956be2079203eebb33beab5880241df1/pyobjc_framework_fileprovider-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:772d963f342af3d2853e4b5a14788b0f72e3c25c457c301e27d8bcdefdbaca01", size = 21094, upload-time = "2026-06-19T16:10:52.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/89/fb75ac1019a89f5f10716d57af5a4a7fb5baa720278c688012f1acdc39ff/pyobjc_framework_fileprovider-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:95f7de1b2a048ac0edd1e02479b13956704b49521fabbd8e94e59564999204b2", size = 21100, upload-time = "2026-06-19T16:10:54.037Z" },
+    { url = "https://files.pythonhosted.org/packages/19/56/4565504252898725ff960d8511318314d10f1c0c887031e30d0e19ac477d/pyobjc_framework_fileprovider-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fe700e447f54a6bca8fdd13a4c21bb93d26665cb4598b958e099d1aca870b109", size = 21385, upload-time = "2026-06-19T16:10:54.874Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/602bdd1faf969d2742af163aa182622ddfecf2ca481449aa7f24ec6bb684/pyobjc_framework_fileprovider-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3bb8b09153e836d3a6223868a55762e5db42830bf58394c1785a90f20c044cef", size = 21145, upload-time = "2026-06-19T16:10:55.75Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/49cb132b6e4fead0b89c2c4c05df9a87717c0a63c26e5c83b139dc3c2a5f/pyobjc_framework_fileprovider-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d62ac3e6dab2087831f9bbb778adb1def9362aacf630cebd2afba16debf1a151", size = 21421, upload-time = "2026-06-19T16:10:56.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1c/440acd08b10764b1adeb6fe21a1eb473e7b840d8727bfa0022a9ebee06a8/pyobjc_framework_fileprovider-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b3592ee88ee6b328a990ed6e70f51a5396ff92f26f25e9a5a706c139d91de546", size = 21128, upload-time = "2026-06-19T16:10:57.525Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/417701fd9cf53fdddd3ba062004413edc28ca8c3ca8df647187de0b733f8/pyobjc_framework_fileprovider-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:a23ac3e9c43894d7fc88e375b1f48f7d8695cf7d0e036d1ecbfdec1596e13a27", size = 21422, upload-time = "2026-06-19T16:10:58.357Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fileproviderui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-fileprovider" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/4c/066d39b6d90f637fdb2d6ab8762ffb234b700e89e93cb7473729b49aa505/pyobjc_framework_fileproviderui-12.2.1.tar.gz", hash = "sha256:40d02bcb15e324af6c624c85f1d65d83f81f31dd72136b0e5ec87440dc0fba4c", size = 12863, upload-time = "2026-06-19T16:20:36.391Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/3c/a030778db1b6272a2ed420a4ebd00a9084df932580c039d48f7891cad100/pyobjc_framework_fileproviderui-12.2.1-py2.py3-none-any.whl", hash = "sha256:2ff2f939ece56f06eae58b9494743941e40500b042a0cf3a64dcf78179d3d79a", size = 3739, upload-time = "2026-06-19T16:10:59.201Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-findersync"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8d/344b385f233b5843f05e7b78bea125123e22bc4c3b0e1eb93d3e55d9664c/pyobjc_framework_findersync-12.2.1.tar.gz", hash = "sha256:be3d41c9b836a53f24473e064ade6bd9ac071cc483377547cb6603e5a0de5d90", size = 14303, upload-time = "2026-06-19T16:20:37.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/73/eb80247a8fb7edd8565370dd7029e3f2e1ec76cc8f78efa1093f73328747/pyobjc_framework_findersync-12.2.1-py2.py3-none-any.whl", hash = "sha256:5b91a226b72a4c83a7ab5bf7e59164d59185021a396bd5804712ba8a55949db0", size = 4914, upload-time = "2026-06-19T16:11:00.173Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fsevents"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/fc/b31d09b6b58e50c8bcd16acf251d397bafc454bff9160f0e2c922cc9cbe4/pyobjc_framework_fsevents-12.2.1.tar.gz", hash = "sha256:f78c98f68bc643794668a9484fc348ef3e98df359db7d8726cada35310af93b4", size = 27163, upload-time = "2026-06-19T16:20:38.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/d4/f1e36b1d4b0216658999028aaeb322da1bae01dad1c8c033854c787977b2/pyobjc_framework_fsevents-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e78bd73365c3c0c42b3adfedbc8a66a7056ea16b84dea9f8af43635f931e48be", size = 13073, upload-time = "2026-06-19T16:11:02.224Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f0/a9025139c69511600b653e4e3bed2b009e0c1d901405cd9d48c6eacfae93/pyobjc_framework_fsevents-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5e863d5b188b4a7bccdda0cc1993b451768ca7425dd866a90a79857d459a2052", size = 13156, upload-time = "2026-06-19T16:11:03.048Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c2/bacaa5063b1e4ec270885fc0a268708c7cdf32b78b129fe753dca5daf470/pyobjc_framework_fsevents-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11552274cdaa97ffa23aa1cb167a6cb03a4b0923330bb75e4757fdd38b61a796", size = 13160, upload-time = "2026-06-19T16:11:03.86Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dd/1c376dd0b434ab505565e239e90fcb77a40d888b9fd052dda85b1820a1e6/pyobjc_framework_fsevents-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:11d13fc2b3bcaa2a746b1f28b95ce9fa9d9078a7da61d6cb4a2f6bc7c163f108", size = 13519, upload-time = "2026-06-19T16:11:04.773Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e4/a0d14951d97f1552201c28f644abaa3b77d221d717b5faeeecf69c7b0c6f/pyobjc_framework_fsevents-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c2b0df089a87971ea2bcc8ecf36696943a9358bb6704780308fc4b392375a8f1", size = 13057, upload-time = "2026-06-19T16:11:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/73/4e166b1c9e7e67e4462970a83bedcfa2d19aff1d0ee1b1db3bce91ccf9cc/pyobjc_framework_fsevents-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7b47592f5ff58553aa2d9365aa7bba89b4bff3f3f2059fb7e0c3811712814219", size = 13513, upload-time = "2026-06-19T16:11:06.432Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/38fa04fac209c1619ce8792a226bf2f0b50e6da52cd9135dd06e4f9ecc0a/pyobjc_framework_fsevents-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b198330738637152999ba90ea49a744ecfcb0d64b1176dfdb6aed90bcd4ab926", size = 13063, upload-time = "2026-06-19T16:11:07.456Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e5/7758ebdc963f2ae70f60e78d5e5b6b9e9a7046d45fcec056ce1ce3793ce2/pyobjc_framework_fsevents-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:81f19060ae21a378b6e6c20cdf0ca1955199af45f3c3423b83dae53d2abb8c4c", size = 13537, upload-time = "2026-06-19T16:11:08.459Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fskit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/38/4d47e4c2ef4a0e474469a715e5244b8e8dde89edde12c94551c5ed3ff7b0/pyobjc_framework_fskit-12.2.1.tar.gz", hash = "sha256:2607cef80fabe2394b30e1e3c10dc942c709afdbe7baacd3f86112b38add942b", size = 49577, upload-time = "2026-06-19T16:20:39.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/4b/3548dddea2ea1ca25e874165f33f2a68adf042701bd2fb297732d77d1516/pyobjc_framework_fskit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:29cda74aaa693513121805726bf458d2a2b60008216f363709c8d224dd0afaea", size = 20587, upload-time = "2026-06-19T16:11:10.63Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6c/c43923e868f915f152cf67bacda50d6e8c44053f0b3b108a5c9a2edcbcb9/pyobjc_framework_fskit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:27deb130e5c3dab34689724a2da275ad83c579bc29da63904e0d2438b4d24ff9", size = 20605, upload-time = "2026-06-19T16:11:11.454Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d3/1148d635a3861e5f10d4cb23097ac797b0adb490922663acfad86b24e1f6/pyobjc_framework_fskit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b6094592998da2b3f61fd6a6599064e722ed91ef8a53e27b0c0cd080575cbb75", size = 20620, upload-time = "2026-06-19T16:11:12.278Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fc/a9a70c58484674873d48343bec31996f913d06071dc4575d6cc0dcdaf93c/pyobjc_framework_fskit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:58f9c31ad24af40b7f37000c31c684a4be1c2057345a921cb0fe57b111d62063", size = 20848, upload-time = "2026-06-19T16:11:13.187Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0d/0936e7af5dfbaae8e1efc3aa9b2b8cca42ca2770991363216edf0e718cfb/pyobjc_framework_fskit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:375ac21b3c028d772bd37aa4fb669aca11f6bd9d6015526f172acd0ace3cc88e", size = 20653, upload-time = "2026-06-19T16:11:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/79/edecf1a9d9857ef8959aa3649572e29f990c864ecf4272712ae5d654b084/pyobjc_framework_fskit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5992fb9c6e0b2b25ed322299a5cba1b239fa198712aa1a6f4e5ba00060350b12", size = 20912, upload-time = "2026-06-19T16:11:14.931Z" },
+    { url = "https://files.pythonhosted.org/packages/18/b5/6b6522cc5ac39162514bcab45d1800fb8a0a915801921275ab67c9917ce6/pyobjc_framework_fskit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f8dd8367162fa1048321183725c4117a0aa6bc1a54be9e289d03f64ba77c1916", size = 20658, upload-time = "2026-06-19T16:11:15.998Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/dc/bba39ec334208768f81c7d88733b7c557a142f164e23da0ecbe7d7826db0/pyobjc_framework_fskit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f6f13449364bc465c9cc5d45c1280aeae9fec9f777d962a0604d456aec0bc6ba", size = 20917, upload-time = "2026-06-19T16:11:16.878Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamecenter"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/5d/a2969d6cb14a9fe10a744a89daa2b671a4fb5dd25354e75511a65f7f8249/pyobjc_framework_gamecenter-12.2.1.tar.gz", hash = "sha256:70fff5b1c0ac9d622709b4deb8e0bdf47cfa43591f1438ce2c6099abd93bbfde", size = 32149, upload-time = "2026-06-19T16:20:40.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/38/f58a4e9ce61da62407a839991960301a61b8ca9568ee376d1e2334118df4/pyobjc_framework_gamecenter-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5aeb41658a2f0f3bc6b5a069f1c74324e3c37f662d54fbc458b0f6894581c006", size = 18843, upload-time = "2026-06-19T16:11:18.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a5/b9a70c5e9e6ea55ffe9c7de8f3378473a4773d476aa25fe20bc5f0420c7d/pyobjc_framework_gamecenter-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e144d257b9461f8195512fb4b1a1cfd4cc0d603583ea039af7127a951ea7ad76", size = 18886, upload-time = "2026-06-19T16:11:19.608Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a5/a09890c3585740684c1a28620ef31bceaa4b455dd1aea59c95a1e30e6bba/pyobjc_framework_gamecenter-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:618fd07d19d715f172338a0d906f5a9e3dff67d3913e47d9033c0e7e4a6f5e88", size = 18889, upload-time = "2026-06-19T16:11:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/43/1b87ab10c0ccac15fa3daeb2bb0d915cb36c605d7c1ac24cd4eeaa3ba59b/pyobjc_framework_gamecenter-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8929a2ca38c79debb975bcd4bb15b0a3bde93f367f90e05cc530badeeae82b54", size = 19172, upload-time = "2026-06-19T16:11:21.461Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/510426e4c61ee1e5a8435348a1cbba2074e23b42e51367acc62fbc2b3280/pyobjc_framework_gamecenter-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a4e8056403464b3ae14a8ecb8ad7024ad6d5672af9cc189436f709952f071e4d", size = 18940, upload-time = "2026-06-19T16:11:22.406Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ac/98cb3210fe91470c9401c0a9e8d5affeb2eb6d8a69364a8f86abf914c103/pyobjc_framework_gamecenter-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0e42fdbf26cde6d8e302d61a2f318de0d33c90060f2a8848722cf5ef0cb2f4c8", size = 19230, upload-time = "2026-06-19T16:11:23.325Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ae/10f18ce863f9d94813ab64859ba9481937713ae901da768c3869a75cdc9a/pyobjc_framework_gamecenter-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b6dbe68dc2e7b7882ba82c295e913999d441caa9c23c868db3a28b351e20909c", size = 18933, upload-time = "2026-06-19T16:11:24.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ca/96ad6ebc2fd96f37915462c1852d47c2828156cdcb2ca8620e3afd797568/pyobjc_framework_gamecenter-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5f61afc1269cee0518b7104c05131a6a652cf19ee2dd97471335c4943e0aac34", size = 19217, upload-time = "2026-06-19T16:11:25.034Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamecontroller"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/94/3f01f6a15b892402e9ec5dd5530e53ce7feab236c374236059ab10961ee7/pyobjc_framework_gamecontroller-12.2.1.tar.gz", hash = "sha256:d40667869da0ef5d9905b4b3c365e275f731758bc0b09f10f7dfba579b1ee7d0", size = 65320, upload-time = "2026-06-19T16:20:40.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/7d/074428109273999cbbd5e4484814207b284f29457a0b065cd97b99f4b03c/pyobjc_framework_gamecontroller-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ef83260973e620207b35bd3a4d68333d76c2e5463f0ca8405efd8327d27f8946", size = 21508, upload-time = "2026-06-19T16:11:26.899Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/97/a55cac5ba675a43b280454a50e377fd9733629d0afcf0bde51c042dd20b2/pyobjc_framework_gamecontroller-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:68d074ef1fbe4feb258e622f58764e79accd006ee39e069f8c50252b0657dff0", size = 21527, upload-time = "2026-06-19T16:11:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c9/55faa145c569b45b1f82d0437e89e84c5d42bcf3b822429eccfdb89643b7/pyobjc_framework_gamecontroller-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:94af74d0229d5ef06e71d2d005a56018930827435778c946cf28ee98914bd0fa", size = 21543, upload-time = "2026-06-19T16:11:28.656Z" },
+    { url = "https://files.pythonhosted.org/packages/01/29/115e4e4ce6d34095fdbc689c1963b6a8688beca380ca5db43b9be6ab3175/pyobjc_framework_gamecontroller-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bb5704a35e501b8902e6210f1f11c7d7f55954dd906847cd6da2390b7176d357", size = 21784, upload-time = "2026-06-19T16:11:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b5/c8e9c80af4bc992bf06d1578736060fbb9955a174528a570aa0ed4172d48/pyobjc_framework_gamecontroller-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:3602c85180be0bc1bcade88f802848e4649850115ba180923c8211311be62430", size = 21559, upload-time = "2026-06-19T16:11:30.468Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/23/fcf75429dd30f4029ec296cc62e802fd98ec3aa965cffd09dc5f76730d8a/pyobjc_framework_gamecontroller-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6a53c426ea670e45027a599c50112af2c4d557ac74e53d553a0f78167f5d7aba", size = 21857, upload-time = "2026-06-19T16:11:31.243Z" },
+    { url = "https://files.pythonhosted.org/packages/44/95/b54d79a802da063dfa7621638f7a4c7beaffd849147fb82bfcf6483cfbef/pyobjc_framework_gamecontroller-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c78519ed3422c5dee9be57a48242b81b482d5339528c7f1362e86efa7231307d", size = 21560, upload-time = "2026-06-19T16:11:32.055Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/aa/b349c94923e0f30ae4224078280662a76544630cc1bdb0f72a6eac93e208/pyobjc_framework_gamecontroller-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:6a63603e317168ae229af7ae7e5ed38644f32732127bdbb6e698bf6e787deb3e", size = 21851, upload-time = "2026-06-19T16:11:32.952Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/f3/6a4ae01c6a8e0e5b74e818694139edf9ebd395bbe04d275fb5f5e73ac919/pyobjc_framework_gamekit-12.2.1.tar.gz", hash = "sha256:e5e90dfa0eba5215406710d636c08ee9aa4ba886d9e0bf11849247b161aef1da", size = 82427, upload-time = "2026-06-19T16:20:41.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/1d/8f369bab83b5fc446de73164e612fa65ea96d83e0c3cd4fe5fd48339c555/pyobjc_framework_gamekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7015d24515e6c069c1cd15c7f2921961c4b9bedc037c3475d068b3a9ce40d03e", size = 22554, upload-time = "2026-06-19T16:11:34.895Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/88/5c93226453c925d22a102df0aef522aac0786168171e1d49b3a15f5bd5fa/pyobjc_framework_gamekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d29a5ee705be7eb0e0fe46bd319462f8bb2f08c8761d65f0e22957f35b6db72a", size = 22586, upload-time = "2026-06-19T16:11:35.828Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d3/467011b105702bfb1e1145bb20863f5c72c49b2ac8f206eb16ed2df76c87/pyobjc_framework_gamekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7fbfa5eeb6c97183aa65f88a8d904bffe79b56db2352dc03ac0a1104c8a6cc56", size = 22599, upload-time = "2026-06-19T16:11:36.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c4/4554e23d5115aa93d1d375c3e17a44c6363174e337754404ecc13d7dd367/pyobjc_framework_gamekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:21b5ca685cfcc64ed05f5dd7a07b6ee852a6bebe251980185e795cc7117fa949", size = 22886, upload-time = "2026-06-19T16:11:37.66Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/91/42aeffba8651ab0ac7e69016d8a27f11f441bb3282568a521a2de1ce8ef3/pyobjc_framework_gamekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a95830e02163542dba2a4573062b151e298932cdfeef2cf48cc2cc63fca97e7e", size = 22629, upload-time = "2026-06-19T16:11:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d9/b5682acbbdaeb87778aeff55ba1b365a94729f6d0ba36c75d9ed71cbc01a/pyobjc_framework_gamekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a4f7fc8e01c9d80edf3d7792f2c35c2eedf67246d12242eea2b480863b642708", size = 22939, upload-time = "2026-06-19T16:11:39.4Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cb/cf33218de97a97824dc7ccb71cf7d8b274d1cef58e2209a18301c010526e/pyobjc_framework_gamekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:239aadec9465eafba7be40293192b79ac572dd0f97c41f3b5c1a2574f85be22a", size = 22619, upload-time = "2026-06-19T16:11:40.629Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/53/b20606954747d99f9f7f86e2ea1cdb78419c087839b74bd47414fb47d623/pyobjc_framework_gamekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b1a9873076cb61f19e792b5a87adb852b21353f6dea675a34c03512de18ecae6", size = 22937, upload-time = "2026-06-19T16:11:41.498Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gameplaykit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-spritekit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/fa/df67a7bd14b44808060dcf82da26492cd7365bd6759d9437a004fb761a32/pyobjc_framework_gameplaykit-12.2.1.tar.gz", hash = "sha256:6ef81407e241016853cfdc6e580503d2d75a452ab0028f5c83390f102685c853", size = 50742, upload-time = "2026-06-19T16:20:42.656Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/0a/552898c2b5585fcfc138b9e62bec6b2d0e85ac1147c59c4544dc45721971/pyobjc_framework_gameplaykit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3cfd99b4a37df41a72f7b15fbbd00abecb11021745bae4876e2d8517f75317a5", size = 13612, upload-time = "2026-06-19T16:11:43.358Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/23/d64fe0c702ff3ee8644bcde26e2c7d9062b19b7d40a60134ba2b4b353b45/pyobjc_framework_gameplaykit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e1ef41d991e29358a26c92916bcedf722568e50ee66eab3088d2e88b9d77d9e3", size = 13638, upload-time = "2026-06-19T16:11:44.269Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/27/4e0e8260e2f3b4a3e99ea756166c9d7b12a971d470376bf417aa4edea133/pyobjc_framework_gameplaykit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b51b11e20066f10532c225262d05fa6711e49685f5ecd9519b6c12ef69efa68", size = 13646, upload-time = "2026-06-19T16:11:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/9f36ade305fcf88bc077924404df1f96ec61e6e6dae2cb7625abca1a077c/pyobjc_framework_gameplaykit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:95b06ed97e4e636140c5d28f507a298974413b501599cdcd2bb80fbc8fb85ae1", size = 13863, upload-time = "2026-06-19T16:11:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b9/143bdf083c3c4cf52430518a97ae515aac2fbd50feacfbab1fe486c1bb9f/pyobjc_framework_gameplaykit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a29a178fe0a64eeb959e1bb719248f7e9e44704b2b0a2f03b4ec6d951750f64c", size = 13653, upload-time = "2026-06-19T16:11:47.085Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/44/e98e8f3f8c131ceed736267f9067835a54ac9dc1d0ffff37dd5634722d6a/pyobjc_framework_gameplaykit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9a4810ad39a1d6729ac164803513043dde33842c19e91c158e645379aab5f873", size = 13850, upload-time = "2026-06-19T16:11:47.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/74/a60cd84430487a8190a2e463d47f5ebdbe81901c58fe6042410b6ed062d8/pyobjc_framework_gameplaykit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f8af54bedd499db1daa54174c0badcb48162601ecb71bfd97c4f7fe77d3ce007", size = 13647, upload-time = "2026-06-19T16:11:48.845Z" },
+    { url = "https://files.pythonhosted.org/packages/70/64/ac578939f804b6b7419e7fe482c353959274db818c36291740f6ca78fd4f/pyobjc_framework_gameplaykit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:720523342cdd978704fd2fea21312f8256d837dd64af2a04c683fbd2daa48995", size = 13842, upload-time = "2026-06-19T16:11:49.652Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamesave"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/96/c4c604170d28f2a2cddb1217dd0d8340ef9435ab2cf1042d85b45a14c2ed/pyobjc_framework_gamesave-12.2.1.tar.gz", hash = "sha256:d317d37f2716194e61cc91e855d6054c3c2b7ceaa82aaeff9c688d9f2cc43a42", size = 13238, upload-time = "2026-06-19T16:20:43.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/4c/8fb1226802cf960ceaac85bbe7bb85aeb949f9c9ae477ecd35876a63eceb/pyobjc_framework_gamesave-12.2.1-py2.py3-none-any.whl", hash = "sha256:5d632ea0b62ef55b1b0f62e8ab6b9800bc14ca78f5a1bb629c95b28376b82379", size = 3750, upload-time = "2026-06-19T16:11:50.468Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-healthkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/a6/a7f9f6d525c19ff1b2533220058cc70ca5bf3976a6adbe2efaa66ff3a349/pyobjc_framework_healthkit-12.2.1.tar.gz", hash = "sha256:d0a8c956746e8705edbe76a046e8c17ab6d7ae2603d8436e4477d30573acb457", size = 116224, upload-time = "2026-06-19T16:20:44.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/4b/6d6cda4263f3a0952ddf7e750023c6af71bec74b18df77a0915a827784a8/pyobjc_framework_healthkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e4d0da98b552ba33532f37ab718bb3b77e15d3c0c1ab426e6d01522d2d256244", size = 22060, upload-time = "2026-06-19T16:11:52.762Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f1/09a7ffbe1dec87ca60cb63c93b81b3f8e6b168e4e24c0fb244809a71bdee/pyobjc_framework_healthkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2c945edc98952bd7d1abad876ed7e36c3442ea6e6c1ec6718ab7554b8a47fba1", size = 22070, upload-time = "2026-06-19T16:11:53.843Z" },
+    { url = "https://files.pythonhosted.org/packages/94/91/31d4365275ce87ce1a0069a25ba1bc33e0ad205eacfe251633dcebd92171/pyobjc_framework_healthkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0408b552eb98319d83a106b25944d645dbe9927dff0ce9c701c25d472672aa63", size = 22083, upload-time = "2026-06-19T16:11:54.717Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c1/213460cfcc6f8f549c942873ed984f6aaa584c01f7874f012fb073693575/pyobjc_framework_healthkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:15d6a4a80a85e29d38371e98f70656a6b378cadbd9430579b9c15a46b81a0a2d", size = 22251, upload-time = "2026-06-19T16:11:55.52Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/bc39d024ae5bd4ad51a4903e8aa8707d55f4707c5bb978233ed5e7caf8df/pyobjc_framework_healthkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d8a44d60387e7e2d54e1d7b613ef93e5701837799bfd962d8d7df08b060d43d7", size = 22135, upload-time = "2026-06-19T16:11:56.333Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7d/35d5265a5da088437c498b7edfd05ad4ea77140ed570844fe6f924d5e929/pyobjc_framework_healthkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9e6fa59e078ca6c4df56eb987a2c6267ef094b5c6a4b386865535da6e3ac2f05", size = 22315, upload-time = "2026-06-19T16:11:57.218Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/90/bdb840292838021ecda74a9498276a159cc0b232dad21ae09c98495fbadf/pyobjc_framework_healthkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f2d2278f3966c7ddf1f828461f11a94373ac3f25a6d052254a2fb0761cf62ea4", size = 22130, upload-time = "2026-06-19T16:11:58.095Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/d971feb74d6faa189bbb9304745a85a823828a23cfb3a967b7d21c4cc886/pyobjc_framework_healthkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:849a6abf2c895db3dd160fcf31b63c229eabbff5cdacabebc0f63e8e49f3c7b9", size = 22300, upload-time = "2026-06-19T16:11:58.924Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-imagecapturecore"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/fb/792b0945e2fb9de91b388e56603f5e6548573511cb40555ca0047d7f798b/pyobjc_framework_imagecapturecore-12.2.1.tar.gz", hash = "sha256:c1568be8cc0fd06046f7e344634951b3c02af3ad4f8a35fe1e2fecd9547b7042", size = 53435, upload-time = "2026-06-19T16:20:45.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/b3/05c58659d8c52516d5ed45cd49b49c574e68ec3c6131e34fc3193ea5fd0b/pyobjc_framework_imagecapturecore-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7d083a0b180b833cc06b6d5419d657b9b96629f24def0c666147acd95ec6c2d4", size = 16042, upload-time = "2026-06-19T16:12:00.891Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cb/f542c35ad49f9f1e33b6e3d43860be84da2a24298579b7f508dd1f0a7e2a/pyobjc_framework_imagecapturecore-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:34165b84443a98ce8b7f12c12603cfbebe09bacc06f33ae1ed3774b649d0cec7", size = 16064, upload-time = "2026-06-19T16:12:01.886Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7a/fc4bf6e0973ef553be039d5651e22ea5802f8095154f41310c1df1a9bb2d/pyobjc_framework_imagecapturecore-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f6882e96cf748096fce49adcddeb882090cb1adb9c6699d1b869866053365d9", size = 16081, upload-time = "2026-06-19T16:12:02.86Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/bb/a7d080589fe074ec317b4022603f60adbab4dd3f671dc16a7516157e16d5/pyobjc_framework_imagecapturecore-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b6339dd78448762e1c017698b32736b809048ae3b0e51d1c625c03f47e59de52", size = 16268, upload-time = "2026-06-19T16:12:03.729Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a5/c502525300c68887985ace05015c4d4a3fa2ba657bf13e6f4e404fda9918/pyobjc_framework_imagecapturecore-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f6ab44c9e3005b1a30de18af8aacd65b8f1a4117ea1017efc72157b3e53914e6", size = 16080, upload-time = "2026-06-19T16:12:04.599Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c8/d17b4a5bd73bdf388e55c6ae4c6c5467be95324bb114fffd826489c47a58/pyobjc_framework_imagecapturecore-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:900ccad9c3ab452017bd3a184ecc7a866d1a8fc599c2e704fa8b62d7f75539c2", size = 16260, upload-time = "2026-06-19T16:12:05.473Z" },
+    { url = "https://files.pythonhosted.org/packages/11/3d/07f1ac5f135b2a88303a429cefb27102d8f5311b2446505b0dc32c37cec1/pyobjc_framework_imagecapturecore-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:ca3bff1d31e453b182c7ff7e91e6cf14e6564ff772371a5d53956204f903278e", size = 16074, upload-time = "2026-06-19T16:12:06.358Z" },
+    { url = "https://files.pythonhosted.org/packages/24/84/b7cbd69f0fe6041368ca6b9f14f1a7de6b75520880d79ea10363745e9793/pyobjc_framework_imagecapturecore-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fb11ecc92fc4e1df467d662afa1a26c89c026daa44b270fe324045b9e38d5c6d", size = 16255, upload-time = "2026-06-19T16:12:07.253Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-inputmethodkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/9c/2bb0c543cfb7a1d38f4750b8b54c57663ec7c54f07499a3218c2a16e3e54/pyobjc_framework_inputmethodkit-12.2.1.tar.gz", hash = "sha256:008d792827ea1b11a051f4871c99c720ca5430395078158f082846cab43b04e1", size = 26255, upload-time = "2026-06-19T16:20:46.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/5f/d82e583e6131717ef7080807a7757ae429dbc0dcaf08e20fe33f42ee0fb3/pyobjc_framework_inputmethodkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ade69fed2930f32434707a39825665bdedb944e835c030c624da5e3a898e2b75", size = 9526, upload-time = "2026-06-19T16:12:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/06/54/eef2b45c70f0ebcc54db74b866753d7a140982519b18f738e9b6c00d7730/pyobjc_framework_inputmethodkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5c979473f54fa344cefc91525b2f7caadb682da7f7cc93f2bf49ba730569f05c", size = 9532, upload-time = "2026-06-19T16:12:09.889Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9b/338f8abbb7fdfecb8a89cd7ecaac0a1853d4a7399c77054b0875b3195e29/pyobjc_framework_inputmethodkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2fb01dfa2c624beafc25c9520806eaf2cc3212c7180a6623a1436d84e84ad84d", size = 9554, upload-time = "2026-06-19T16:12:10.749Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2a/d65f3b8606d8f32ae125e434fdf7aeadc5de5ececfa0f543c7cfd1c65b65/pyobjc_framework_inputmethodkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8d02da4d81146258fae8f2571b47df41a912b0e1f84bb38384e1a4d858feaf28", size = 9715, upload-time = "2026-06-19T16:12:11.541Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/c57dd6e1e7acca699c9861801334337478368327ad7571dc4d63c5a4ead3/pyobjc_framework_inputmethodkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9b7754bcf52aa753cbb616eaab5834f13b8ef4bdd163c89ad2f921e8fc89c05a", size = 9599, upload-time = "2026-06-19T16:12:12.473Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/ce41a93ef757dbbb3537f2d9552a7fbef05cb928315e67d34f6b3667968b/pyobjc_framework_inputmethodkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:017c2b316fa6f4477b4395b21a276e2caef8a4c558411110271b267bdd1a2276", size = 9767, upload-time = "2026-06-19T16:12:13.494Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/13/9196e22ccfa58996547b0ebc1931e3c6aa9b1ec2425b05d859db4ff476ce/pyobjc_framework_inputmethodkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:ea2503ebbae052622c2fada50f445766906757b4ddccde3c2e66993703fb0393", size = 9595, upload-time = "2026-06-19T16:12:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/4c/f79bc867cf5b06c5fba04422b6a7a690ea8c0b9f8c88d5f04bf5818b516d/pyobjc_framework_inputmethodkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:05886f2ab68f06693cd5c5c6f8a99a37ddebcd5a085d98ebbfc8b001b31a122d", size = 9766, upload-time = "2026-06-19T16:12:15.066Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-installerplugins"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/2e/23d4d49b755fc6e179956d745311115dbff6b43a505a8ad627a13a301082/pyobjc_framework_installerplugins-12.2.1.tar.gz", hash = "sha256:118ee84e6e7f6f7913ade58818bfd2c12e2078ff7f6090e4941df1e739c8685d", size = 25978, upload-time = "2026-06-19T16:20:47.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/16/7ae359b8f858d6caeb076d779ef1123ed2f1d287e5e9a7262f7355b25819/pyobjc_framework_installerplugins-12.2.1-py2.py3-none-any.whl", hash = "sha256:aef22bff292d3b8fb9cb655f868d041dcc76d3d6b47d3022557fe3f657c28c69", size = 4841, upload-time = "2026-06-19T16:12:15.946Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-instantmessage"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/66/89688001f6b1a76a09876b4fbe02760994b783d031e05b3d7e039514748a/pyobjc_framework_instantmessage-12.2.1.tar.gz", hash = "sha256:80d31bca02459c6d2364605b51a8064d0fbe3e7dba085b5b8ac59ee98157710c", size = 34047, upload-time = "2026-06-19T16:20:47.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/0e/b042906e81eb1865b123ef529516af7b2a2bc28f5bfbfd7b0e0d40a9f1de/pyobjc_framework_instantmessage-12.2.1-py2.py3-none-any.whl", hash = "sha256:42c7be0357b1d4e808b40c7d212f5d807e1901a87e0cbb6a215bd0232f87374d", size = 5464, upload-time = "2026-06-19T16:12:16.821Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-intents"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/a9/107e313345eef0a2be05017227073678b65b58f77af14312ff6403999856/pyobjc_framework_intents-12.2.1.tar.gz", hash = "sha256:579a36b1c2dae423ecf8f7fc02fc8a2a3d079366a073903ba323d40adeeabc2a", size = 187763, upload-time = "2026-06-19T16:20:48.645Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/3f/848e213c2e9424c5304aac6a4ac26f7ab53088bd58fd5a950c23246862e3/pyobjc_framework_intents-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b6e0687c4dd12ebfd8f057364b2fa7367d324957d514747d8dd109083486d422", size = 35259, upload-time = "2026-06-19T16:12:19.041Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/cd105a3a262e9048accde15734d84869ea6d2e1eae95a9f5c32dfcb9f2c1/pyobjc_framework_intents-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:440fb3b4f2ffe3184f3fc8ba0abba83a3a59ba63dad12a5bb2b6792eab8722eb", size = 35276, upload-time = "2026-06-19T16:12:19.958Z" },
+    { url = "https://files.pythonhosted.org/packages/28/22/4f3a7ca8f8fd8a646074f2e9fae8798d2c8e9378d8fa191085b2b1abaa27/pyobjc_framework_intents-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c21cf1db00b8c997d3e6cfde53ec135ddee5b03138cf184deb842dbc925c1286", size = 35293, upload-time = "2026-06-19T16:12:20.884Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/59efde70a85b826bd7328c2d77fd19163014b571f0dac1543c46a1fbd143/pyobjc_framework_intents-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:21ed7ca804106bb1a606c070a081d59dc93fb23bd570a802518a8ed36357c275", size = 35529, upload-time = "2026-06-19T16:12:21.746Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/29ec0832512c3db3d5708eaa4f5ab4419aea65f2e7e6b4aeaf4f413b6086/pyobjc_framework_intents-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8fcc3326ed27b800a5da3e8634cdddd6506efd0c73a95f5e624f3dc963516baf", size = 35308, upload-time = "2026-06-19T16:12:22.626Z" },
+    { url = "https://files.pythonhosted.org/packages/34/dd/272debdcd22abb68d5b9574aa9fb87da590a281eb663f2bcf7ef9f0c9327/pyobjc_framework_intents-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1b4dc0c62df523a3391dc43c754cc9a4cae7334342785c882be0fa76b2ea22c6", size = 35597, upload-time = "2026-06-19T16:12:23.62Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f0/2aaae2250c7346d0c946a404aa7a6901b9bc2394ce986f7094e2167f53a5/pyobjc_framework_intents-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bba9340e7ec61747a5545d4fe569d77a3c10e870d1ec06a9e17412c29a1fdd07", size = 35317, upload-time = "2026-06-19T16:12:24.497Z" },
+    { url = "https://files.pythonhosted.org/packages/03/9c/fe3f1cea21ada9707e184cfbc6e661c4833fe2a68c4bb4b37123e775d8fe/pyobjc_framework_intents-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:18a726d52b4a24f6a274c094b1abb5cd757d1f29946a8058c85a32bc0857dab0", size = 35599, upload-time = "2026-06-19T16:12:25.398Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-intentsui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-intents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/31/1426d5ca5dba96d82dc08c6f287361eec9c3d8008295403b015843bf7b51/pyobjc_framework_intentsui-12.2.1.tar.gz", hash = "sha256:ec1a0fa3861911da7e43abfb6f783052644d62f587554e15a06303a648f9f361", size = 20768, upload-time = "2026-06-19T16:20:49.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/14/8946ca41f1f9b113fc8df7da720b7813ff1851b1f14588cde54ba620e41b/pyobjc_framework_intentsui-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ecd53ed0f5f234d690985bee9eba1ee94f34b7d206f2d375fbcf6691fa446e84", size = 9027, upload-time = "2026-06-19T16:12:27.267Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8e/6cb7c5e2a9cf64fd1bacdbe103dc0355f85fcebbcedafeacdca9ae3678c8/pyobjc_framework_intentsui-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b8f92e0018ca0d720f339b589ead6b46443b95f844258eb4f0a215101a74eb1b", size = 9047, upload-time = "2026-06-19T16:12:28.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/7b/06fa5e8a04202dc42ba0eb0887ee362016417074343602cd1ae97a811978/pyobjc_framework_intentsui-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3200f217607900018605f8b25a75d1e5b2b6739e2244b25147a77d9278ff745c", size = 9064, upload-time = "2026-06-19T16:12:28.935Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/bf/6bd5674aecf4f745fc1bd4ce0c5d75e4b562e43d8cdd65856d1665d998c3/pyobjc_framework_intentsui-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0af7ede17b56defe1c19426e5b5f2dd39d8215eeee30c6dcd1501dba609566d0", size = 9245, upload-time = "2026-06-19T16:12:29.777Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f3/05119d645544e385d2ce402c3219f2ea46ef3a09aa58687704f81c99fba8/pyobjc_framework_intentsui-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0d3088164f6028b0f8eda429345f3ad33c7b8c70ca8ed3d75d178bc62ccc96f0", size = 9118, upload-time = "2026-06-19T16:12:30.597Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e5/62c2e46ec1a8cea1aafa74f4262246e48eabf781312b58e79f0dfc354adc/pyobjc_framework_intentsui-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f91ef9f61f65dcbf08b5277cf947ce390393eaf4829800d6aa5132e49dde6888", size = 9313, upload-time = "2026-06-19T16:12:31.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/2b/3884fbd8920ab24401f9dbcfd381e285a3fab1314fb3464666090e862779/pyobjc_framework_intentsui-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8bccc0dfa36cf12ee4de87195d1caaa8ba15334658cb06c81c6da8bb44a2c9d7", size = 9113, upload-time = "2026-06-19T16:12:32.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e6/54039e403a04afd25456953ce6f1240cafe0f2972e199c93b629b4029e06/pyobjc_framework_intentsui-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:70d30672d1b7213ea7018b7bf53bb37000179429f83759a471dda456bb07bdce", size = 9306, upload-time = "2026-06-19T16:12:33.565Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iobluetooth"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/5c/acb79d6180b7dc243b82c129292fc2c9e1f695793165dd6e89f55a000a49/pyobjc_framework_iobluetooth-12.2.1.tar.gz", hash = "sha256:eb99c27187c68f984dee4e9ac620f5b210f11f821a2063b2fb9161359a1f1754", size = 174846, upload-time = "2026-06-19T16:20:50.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/0d/352fbaa3c33de658760e1de4e9c2276c77a1e6964d8f4aae38250f54f960/pyobjc_framework_iobluetooth-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e3c3fe2e35d4b20cf0ffafe1ee234bb250c742a3e348abb299df6e348e92922b", size = 40539, upload-time = "2026-06-19T16:12:35.521Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a0/59dd27082e6b01ab5f181a465ac86ce62ab5353d477254d78472afa7c26c/pyobjc_framework_iobluetooth-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8ca12b1ef8533fbd63c44c68ad80afe7ca0446f056399305e9f51f573c406b42", size = 40560, upload-time = "2026-06-19T16:12:36.361Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fb/aa00b0c445d1a20d8b67d67348c8890d122c1d1e76a5735b8e14c28649cc/pyobjc_framework_iobluetooth-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6d5e76af8d2f0ad9f0a25158c0aa6dafa2dc59c57135dd1d4f39aff89e898344", size = 40571, upload-time = "2026-06-19T16:12:37.155Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/be/8d058fb08b3ce438e9878ca27e6c91d4e89e7cca9de8eb281317ff3d022f/pyobjc_framework_iobluetooth-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fed3eb2ce6aec555f1e22d04d06d2212a1d475740eaa2b832244198e09b5ce11", size = 40787, upload-time = "2026-06-19T16:12:38.145Z" },
+    { url = "https://files.pythonhosted.org/packages/60/69/763ad564f5ef8bde212024bdbfc750c0e0a73ec1f2ff5562f155669ef5c7/pyobjc_framework_iobluetooth-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:18c9b901de39aeb79ce36bb4e550410ad5112917bf7f4198776c25c07099ce0c", size = 40564, upload-time = "2026-06-19T16:12:39.004Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c2/65cd8eff70014848f1584ecd6e534d12062e4543db16c963806797dd1540/pyobjc_framework_iobluetooth-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9dfa596bd8fc4d1648909c04b2856193e627dcb46ceecee9997085b99e395a8c", size = 40765, upload-time = "2026-06-19T16:12:39.807Z" },
+    { url = "https://files.pythonhosted.org/packages/41/c0/d16c0daa3cf2214301614641e83a49aed33eacbcd9f30505bbd3552959aa/pyobjc_framework_iobluetooth-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:aeca5abfaca23d204d9a4a32b68aa854b1d2893cfc593f0c3dab69c106c8ec63", size = 40555, upload-time = "2026-06-19T16:12:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/14/9fa4e6f0a7d990c9d0216d77222595991d3f802627dd089e4277890d46d1/pyobjc_framework_iobluetooth-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c80d734d08e2fd5d4764e0039693792fe2a7799156c08501b6734357a11e6c5e", size = 40761, upload-time = "2026-06-19T16:12:41.856Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iobluetoothui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-iobluetooth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/79/99c3fce73768d0fbbb9c2fbb9dda092c828c8d15e9e5ba4dd802b719582e/pyobjc_framework_iobluetoothui-12.2.1.tar.gz", hash = "sha256:53bbfa9451c3c1bb55e91f063bb0539509e1e2b11887736967cc218b93695087", size = 18013, upload-time = "2026-06-19T16:20:51.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/ea/015e595050aecaea98cfd9cb62d93bd86408af7550efc405d9bc661a69c2/pyobjc_framework_iobluetoothui-12.2.1-py2.py3-none-any.whl", hash = "sha256:321160ac3181349054d29f7804b24944549fe442f4d6840f9123bbcd48f62aee", size = 4066, upload-time = "2026-06-19T16:12:42.682Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iosurface"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/bb/9f1b513ce177d725b6aa0936f69ece74afa695698ff2f59660b427824b4e/pyobjc_framework_iosurface-12.2.1.tar.gz", hash = "sha256:f886630d6f2419fed9f89152b1e738758b735219bd39506bc12c2e1f65456dea", size = 18604, upload-time = "2026-06-19T16:20:52.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/22/c1a95f27988883450ec1c8210f351da5fb006c753d686e8437426daf821b/pyobjc_framework_iosurface-12.2.1-py2.py3-none-any.whl", hash = "sha256:92cf617b6ad6c216ec5fcdd47584fa0744dc7ff38fee378b2689dfcf46194df1", size = 4925, upload-time = "2026-06-19T16:12:43.545Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-ituneslibrary"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/9d/1b18df4c94a4a45cb9fc86edf2656d1932c1f56c31dcf6ac673cd9138808/pyobjc_framework_ituneslibrary-12.2.1.tar.gz", hash = "sha256:be3afc865881c762765101be35f7216616c5eb4c76025f590e36fe1cbd2518fb", size = 26184, upload-time = "2026-06-19T16:20:53.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/7d/05c50a1bd493ccc1844a89461ad7eb82b7ea7a361ed219377f8abaa625c4/pyobjc_framework_ituneslibrary-12.2.1-py2.py3-none-any.whl", hash = "sha256:076712e495e2df43dad14e92167e468c4a46b9d06f1b84b98b2b65ff24285043", size = 5237, upload-time = "2026-06-19T16:12:44.426Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-kernelmanagement"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/34/21b155304cd14f2b6ed9b732c2925b1c23c6eb1a941676e83d972c14dddd/pyobjc_framework_kernelmanagement-12.2.1.tar.gz", hash = "sha256:49591c0603057d2ea2596b9b414c38fe521f506e1320753bb49ccb2262b97bdc", size = 11961, upload-time = "2026-06-19T16:20:53.903Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/57/4b0e4520f06f62e3a70eb50249efe750fd220fe23072e021048a23a2eeb1/pyobjc_framework_kernelmanagement-12.2.1-py2.py3-none-any.whl", hash = "sha256:9facdb93e49717a9e5999ab7b20cd1643ce00119f7b91c4933fec0fe3638edd1", size = 3696, upload-time = "2026-06-19T16:12:45.473Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-latentsemanticmapping"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/37/35c98e572e98df7763c6d7bc437c7aee7d5a36c030c51841d793d0e89939/pyobjc_framework_latentsemanticmapping-12.2.1.tar.gz", hash = "sha256:96e6b523c7fe7944cee30b723f035f9082500c3bf8ba8237013c8e37b112c493", size = 15906, upload-time = "2026-06-19T16:20:54.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/80/1e80736b58665094f12ed736f1d675a9658ebb992e33fea72cef35815010/pyobjc_framework_latentsemanticmapping-12.2.1-py2.py3-none-any.whl", hash = "sha256:7d7669ae5c6ca53e6aa7bd70ddfed23914a29169c3f57b94a40a0397abaa66e2", size = 5499, upload-time = "2026-06-19T16:12:46.356Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-launchservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/8e/26d4adeb32fcde532d6e3afd342ebfe055017f183b2c2f730a28f1b3de84/pyobjc_framework_launchservices-12.2.1.tar.gz", hash = "sha256:1d288543c1c4e53e6e24314987e18904ada821d6bef5437e6bd9e8e6873fe4a6", size = 20834, upload-time = "2026-06-19T16:20:55.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/5f/6ef104cc5c2724d07ebd119ad20c80d40a964f1074e6c72053b5d658556c/pyobjc_framework_launchservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:81ca37abab29e96ebd69e1d97d63789d729510a6fe1f6cd4041e5b24f340f115", size = 3934, upload-time = "2026-06-19T16:12:47.283Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-libdispatch"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/3f/561653aff3f19873457c95c053f0298da517be89fdfc0ec35115ed5b7030/pyobjc_framework_libdispatch-12.2.1.tar.gz", hash = "sha256:0d24eda41c6c258135077f60d410e704bc7b5a67adcb2ca463918896c7363795", size = 40336, upload-time = "2026-06-19T16:20:56.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/b0/dc263ed1cee54badccaf60f061de1e25bea95504984401a22bee274b5f59/pyobjc_framework_libdispatch-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e295775c76eace23f60e53ef74b0f79429c665f91a870e4665c4b9887466efa", size = 20488, upload-time = "2026-06-19T16:12:49.441Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8f/42cfa987c07a2b5ce8c236a42b0fb388b8807dac72c25e004cd4905ea9a3/pyobjc_framework_libdispatch-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8f41b5021ff70bc51220a79b41ebd1eacb55fe3ceb67448594f30e491a2c42a5", size = 15656, upload-time = "2026-06-19T16:12:50.361Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/cfe97f1beb13f5b7ca5c4348158c2de886d58ffba5be09a9376557f7d6f6/pyobjc_framework_libdispatch-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9c0ebf99520083bf17c007a544c100056a0d4ae5c346fb89e1bdfe6d041f16f2", size = 15679, upload-time = "2026-06-19T16:12:51.28Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/de/ef6b51bc72fe5ac1df80c34b1b13a97d0922ddd6bc5d3ecf5ead1557bf34/pyobjc_framework_libdispatch-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3f56fd71b963a0b6e440ed2f0ea2fb635221758b7eb908ba38f96f5144b83ca3", size = 15946, upload-time = "2026-06-19T16:12:52.098Z" },
+    { url = "https://files.pythonhosted.org/packages/42/87/5b4a6c8580f2a486daf4b0d14a2356c47abfda401b329e71e46ac9b5460c/pyobjc_framework_libdispatch-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:999bad9a2c9198c837ba8f57a3ca9f05b4fc4bf7b69318baaa266dd2ab2fc8f7", size = 15699, upload-time = "2026-06-19T16:12:52.917Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/44/68cff50cb37a6ea311b7e805105ea13c33043762772714bc25d269c0730d/pyobjc_framework_libdispatch-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3fc93971f40d9757995c1e4b995a1614a468a5178be27e3d81e9bdc0b5e3cf75", size = 15981, upload-time = "2026-06-19T16:12:53.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/5d/1f48e023555817f1271e86849ebd092743fc8bd292b6f82e87aba5df6122/pyobjc_framework_libdispatch-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:26a096c81c8cf272f4f1bb8f6c4b7565e005d273d218b53b83d925da5292633f", size = 15719, upload-time = "2026-06-19T16:12:54.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/44/b45c32851a3bcd367c62804c23aa55ea7918af6e16fddf1df23f5d7ca750/pyobjc_framework_libdispatch-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:82c6512fb4985f3bcd6b60b0cff79a4b483b44d1d2e5405010e34dd4b60aa01b", size = 16009, upload-time = "2026-06-19T16:12:55.513Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-libxpc"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/e5/92d47d5387baa85461be9802dccd90f6fe9232a98878caad7ab899d207df/pyobjc_framework_libxpc-12.2.1.tar.gz", hash = "sha256:83b814672715ef1f4f83eaaae49416a77db38579e6f6af2e14cd328a76f5d598", size = 37265, upload-time = "2026-06-19T16:20:57.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/86/e5110414fab0191fa10c5f9901e5f9feb4c8dfb3df3c3099a23e7c2000da/pyobjc_framework_libxpc-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:157db58d0bf530d7a2838c3229aa5fdd973fc2359beaa557fa3ab370ca541637", size = 19649, upload-time = "2026-06-19T16:12:57.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/27/ab74145db0b6e9eafbcfe24ee5f906f1466ecfa40265b20120affb48f946/pyobjc_framework_libxpc-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:905964e12dd9180e70bc88bb04cdc02e4920a48a045e62ebb47f207ab3085376", size = 19774, upload-time = "2026-06-19T16:12:58.453Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3d/6432bb6e2333b3dcbc8da1fe26f4436895e3b7046efb70c4cd8c0ee92aea/pyobjc_framework_libxpc-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:158fd1b11eabc4c42d1bb60264ecd19871c3e24ab661e7c6d982bcb5b6cd8da7", size = 19780, upload-time = "2026-06-19T16:12:59.378Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/89cb0149bd82f25f2555e9195d7d8f24be979fd7e88ffda0db6e6e61cbc9/pyobjc_framework_libxpc-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dad8ca82fe4162e85c9a6057382eaa6adc6b3aa22011e1e454d6eafb997dfc02", size = 20332, upload-time = "2026-06-19T16:13:00.296Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d0/afe32cbc4c7cd5a5856532ebc6b90b26d25beb244522a1d13e106a74787c/pyobjc_framework_libxpc-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1610ef8016bdeb83d2193851e5c19fbf6073741d01a0d590afa4501531b788e1", size = 19509, upload-time = "2026-06-19T16:13:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a2/590645eae51a2aa113bf1221351738a6d00b7144323c98a1b08c2702e72b/pyobjc_framework_libxpc-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:90331eb7dee2a50e6cd70463dd156d7f679919b9d03e52864707bfdebea0adcb", size = 20038, upload-time = "2026-06-19T16:13:02.033Z" },
+    { url = "https://files.pythonhosted.org/packages/19/35/87cc08847d11d21e385bbdb90d3274230ceabec8cdfa0aa021eb36aced09/pyobjc_framework_libxpc-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:88bba9ba27aa974a6d89dc1bbb5fbec1d96407ac36f01737ce92179d1b1d383d", size = 19515, upload-time = "2026-06-19T16:13:02.846Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b4/e24b80803a8e7e77fdc8caf36274822c9e13fec173467b21786625bb0462/pyobjc_framework_libxpc-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:153ba3845c64a9f8003a87f22de4b4ec678f2c36c329c8c3c96c30cffe7a0570", size = 20062, upload-time = "2026-06-19T16:13:04.185Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-linkpresentation"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/21/368316aa17c5a70a29fb5bc23d29e8608509de539ad5402b8e273dcae5f9/pyobjc_framework_linkpresentation-12.2.1.tar.gz", hash = "sha256:96f30800eef18543a4c75fff6b1a7cce7fcd649564784cc523341870908382c9", size = 13978, upload-time = "2026-06-19T16:20:57.903Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/14/76bdc42790ced9ab3be43a946a4466a0debc3d7e7642fa4836081768c382/pyobjc_framework_linkpresentation-12.2.1-py2.py3-none-any.whl", hash = "sha256:2299fc001002ecf501249a0a61bda35d50aae5057c9f2aca36274261add4fa4d", size = 3887, upload-time = "2026-06-19T16:13:05.149Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-localauthentication"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/e8/fcbea8814ab28d00e18e4f6fc84af2fbf58eee916bfe85a30685abef0729/pyobjc_framework_localauthentication-12.2.1.tar.gz", hash = "sha256:05162d6d603fe6a9bf8eba8d5df7da379bc2b8eaf2a405bf0132a71477f5ed1c", size = 33086, upload-time = "2026-06-19T16:20:58.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/d5/47486c13c3481ef868411f61dd4c4f99bc8a45f5fb2675da132160211817/pyobjc_framework_localauthentication-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:be6c72699cc3c3a970483f1cf7fce3b40663253202ac023b8439d34f93ea224a", size = 10896, upload-time = "2026-06-19T16:13:07.216Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/60/5c4f1fe4e70dc68ddb3d55dcb8f81ae7806972fa37108a0f9a394020e657/pyobjc_framework_localauthentication-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:591dc5bd8143868c0414a487c433d6c651c44c3f0ec751ad30ff3e0f4260db6a", size = 10905, upload-time = "2026-06-19T16:13:08.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/fc/ca8853e87bf1d1bcf2a1331eef8f410a7177aaee6f019c6ee99036d28592/pyobjc_framework_localauthentication-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:29d6de29ece22d49a95279de80405f1441ccec74ea30db5251ffa8f46c51ae94", size = 10920, upload-time = "2026-06-19T16:13:08.781Z" },
+    { url = "https://files.pythonhosted.org/packages/61/af/3a02c67f96bda4f1a2d3d3e5923e5ec70946b62e054ae64b6dfa81695ab9/pyobjc_framework_localauthentication-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:52f89e993950b66d2ec701fb2d5f523a5e6dfafb8e0da9c194aa4fc5aae3a30e", size = 11063, upload-time = "2026-06-19T16:13:09.615Z" },
+    { url = "https://files.pythonhosted.org/packages/40/40/3f4d8628b4b60cbe6ef1c9d96250b4f54854e4f0beecc102a80594899cbc/pyobjc_framework_localauthentication-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:326f9bea423f705d61bdd36ebae087ade99c39c91fcd6643780697d539e8a575", size = 10962, upload-time = "2026-06-19T16:13:10.429Z" },
+    { url = "https://files.pythonhosted.org/packages/04/32/d289d8778665de6098a0f6790198dde03946985ec46dfcd438acd7c99d05/pyobjc_framework_localauthentication-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:49a99b96196e1ebe0791ed546bb538d4c28ee4ffbdd1b0e4c7666d063104f849", size = 11106, upload-time = "2026-06-19T16:13:11.222Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a5/8310eab80699cf11329de3fc7e1ecb276c935f53ff29f3691d72eaa870c3/pyobjc_framework_localauthentication-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:867541c093477d5ed26efdd911fa131db533d837cad575cfa5930a1fb5d7f434", size = 10971, upload-time = "2026-06-19T16:13:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/42ac5c192d2c2c1bb60d91af9e85ed357f3d8f4957056326745e0631609e/pyobjc_framework_localauthentication-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:aa094c1a5b2dbb02fb3be32a0a5fcfb23aea21815827ece2655737d4b8dd7af2", size = 11100, upload-time = "2026-06-19T16:13:12.813Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-localauthenticationembeddedui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-localauthentication" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/be/1cae60d052314b16e2e279cc187b918637e6afa7f3bc7aca6eb2ae6c2256/pyobjc_framework_localauthenticationembeddedui-12.2.1.tar.gz", hash = "sha256:f97666380541a40e593c7ed2214c11da30effcc909a4b13595220050a9888577", size = 14146, upload-time = "2026-06-19T16:20:59.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/c5/42b5b4260d20309ab9832c98bbb20585191248c846036e8975b9f194809e/pyobjc_framework_localauthenticationembeddedui-12.2.1-py2.py3-none-any.whl", hash = "sha256:a77da7a7471ee9277d4ae7269fb3d0bc508c5908e93ccf8e4cdf723bde21d1af", size = 4013, upload-time = "2026-06-19T16:13:13.559Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mailkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/09/49fc5fe2ba2489b2844e2a2f25cf526718f34c53847009fff2e9b1f94fc2/pyobjc_framework_mailkit-12.2.1.tar.gz", hash = "sha256:8a8e84f6828f13c7c67c6f8f299889127df05d25ffe52b6c942d69a329681c75", size = 23888, upload-time = "2026-06-19T16:21:00.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/cc/4a9e1f5a387df7e5bec26ad3488e414d6fb065c46131072d20f07a6314f8/pyobjc_framework_mailkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:e453e42d8ad97f58593296a85c71ec8c71378f8d5d79ac4548845f5dcba725b9", size = 5018, upload-time = "2026-06-19T16:13:14.528Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mapkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-corelocation" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/29/6f5a817054f8998629ae4c8146674a78850a56477ebbc8e6cad2732dad3c/pyobjc_framework_mapkit-12.2.1.tar.gz", hash = "sha256:b0d34e03e100adb471b91f0915b6ecb2266251886e54a1729ee534ec832ad392", size = 79578, upload-time = "2026-06-19T16:21:01.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/ae/8e0b03353841dbf36a380ea73fba3202c98ca94c47137fafaf04811a7b83/pyobjc_framework_mapkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c312c5ca0634c6676328c9b205d36fcd3138eacaf339480b9e9572e0c579e9d5", size = 22833, upload-time = "2026-06-19T16:13:16.587Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/29/45ae9a8e02b487270d29cc65e968cce3ea82c9b1fc6d208bc3d305c40f8d/pyobjc_framework_mapkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f423892cba28bef2becdc5cef9011e358f223b66478aecc8ae5e3083c8e1700f", size = 22863, upload-time = "2026-06-19T16:13:17.659Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/bdf2e3e7e6d5a05fb9fe11de7d8b85f75e49eaa3b31a8c7b45b2f28f804e/pyobjc_framework_mapkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e94362c148355d36aec29d7a77c14178e44e464504dd2cbcc8de28b18a5e00e8", size = 22890, upload-time = "2026-06-19T16:13:18.735Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a9/744ce0d68454c29522d8dd97a00f4a260cc06941763a2ac6cc189c653e66/pyobjc_framework_mapkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9c128d8e4af7698629545d5761cc1fca5a26a3e13121c2ff7c77e28308922b70", size = 23075, upload-time = "2026-06-19T16:13:19.855Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d4/2b796d0da8e2d90d7402ff58070c61a16be33c842de4eb270d2125e72749/pyobjc_framework_mapkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1263fb5c1e13ad7d34e60b455cd56b79627b4505488cbaaacee9ad8acf4eee80", size = 22914, upload-time = "2026-06-19T16:13:20.785Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/59/adf23b8bf39f02e8820b97eb50f23fb145d7f6d43a471f1b3047ed0209af/pyobjc_framework_mapkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ceb93bb2aa7ced0dc200508d9baa0de2438f8e0194f1dfabe7407ab0d734bafb", size = 23120, upload-time = "2026-06-19T16:13:21.632Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/64/87caba8d8a9cf4f2556718839a9fac9c9958b1ef3d6933cc4c93cb39bba8/pyobjc_framework_mapkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:5b39d0cbeca27e3eef130e5686adc8e0edd06981e0f8afe359ca070ed790f329", size = 22920, upload-time = "2026-06-19T16:13:22.518Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d7/b953ae58dfdef45fe6360a1731986d519277cbf087037da4ce9a89d42f76/pyobjc_framework_mapkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f9ef9633e84afa849bcb923ef0ee9cc78106d210e45637f58941dca4408681f9", size = 23130, upload-time = "2026-06-19T16:13:23.362Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaaccessibility"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/46/c07388b3911f10cf84347c0fc7b250792e6bdabbdd9a51083331b8ae58ff/pyobjc_framework_mediaaccessibility-12.2.1.tar.gz", hash = "sha256:6d816a09d874519bea85035db7c62c0566063a5be63e3ab25b2059205576ade8", size = 17250, upload-time = "2026-06-19T16:21:01.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/bd/bc6277582c43eb6b4916cbd411352bd5066fa3e1b48ed5add4e41932e4cd/pyobjc_framework_mediaaccessibility-12.2.1-py2.py3-none-any.whl", hash = "sha256:8543ff6664ce35815083ab10a6f4b1b9241594d60c27132e08385b0316d55013", size = 4847, upload-time = "2026-06-19T16:13:24.243Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaextension"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/fd/8f2489cf3673a705d806124edb73ea27438919f58af1fa41dd789163838c/pyobjc_framework_mediaextension-12.2.1.tar.gz", hash = "sha256:d31057582878ec2574559ad253fd448de3f11a68e454d14f0665348c82b3dee0", size = 44554, upload-time = "2026-06-19T16:21:02.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/12/4606689b0259defde9897f6d046fbfa72360520a9a97e78c9739c760a314/pyobjc_framework_mediaextension-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e8d383f458e4812993a0b4132f128a588ea34d9be51644261ddd04f90cf530ed", size = 39032, upload-time = "2026-06-19T16:13:26.521Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6e/3b9f69ef0caea40e6175e4226a9a8df7c7997cfb8dbe6ca430575c21b4df/pyobjc_framework_mediaextension-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bbf5ea3683dc5b6a2b0f218ec0e9935a21e6aebe7d00760be78395268fb04770", size = 39048, upload-time = "2026-06-19T16:13:28.614Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/02aa57d87451fab20d27c270545243e4868b2172b0519f75a1c7755a3e04/pyobjc_framework_mediaextension-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:600e289380d19b24d7166027988c63b5fa8cd297a379fa9538dd0bcffd527c0a", size = 39062, upload-time = "2026-06-19T16:13:29.79Z" },
+    { url = "https://files.pythonhosted.org/packages/05/4e/a338813ca7bb23e59d44c15eea0c43d2120de949c93acf408117b17f4051/pyobjc_framework_mediaextension-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c84027e9c775d51ae58c5c532935145ef1ddaae7b24b769e6ff7026b62a7e4ea", size = 39263, upload-time = "2026-06-19T16:13:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/33/5079aef3cfb5740e11f214d8c5ae9318e774f66a8891d72524f1ea2c9384/pyobjc_framework_mediaextension-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:1f5554002df229352672d5d2f7ec5b8d63cb8fae762df67da7ce0902ecbd2837", size = 39051, upload-time = "2026-06-19T16:13:32.275Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/16c437191e23c781a61e8008473ace2a4ddfe2f9151c3236427c3ed2c2a7/pyobjc_framework_mediaextension-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:116d9cf91c283bd741ee1f5f8350e858d002a002c655b0378c471ec0d81ddef5", size = 39263, upload-time = "2026-06-19T16:13:33.506Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c6/07abc4c226c2b81457b2aaaf2fa349cfcb26a997117f70292343e431d435/pyobjc_framework_mediaextension-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6d3779c1923a059b8d5c4e5ec5c190d015f63270d4d657e0f5ad1a97df99ff19", size = 39046, upload-time = "2026-06-19T16:13:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4b/c14389fc31083b0f5ac3efdaa6d580ce8099300e5028a96c370d67e78355/pyobjc_framework_mediaextension-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1f0da78f3ccedc09db0d8dfa6d6c008fbb411e5f9eb52c4dc0318b57416d37c1", size = 39257, upload-time = "2026-06-19T16:13:35.423Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-medialibrary"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/3b/af0d8cf4bef550b77ecddea3db59bce0ab3ab5e22e258c583e92ba5a630a/pyobjc_framework_medialibrary-12.2.1.tar.gz", hash = "sha256:18fb56e727399f11ea588d2c512b7585147386892d72c65eb9c4b6387abd6643", size = 19052, upload-time = "2026-06-19T16:21:04.063Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/da/9f38ae220465c54ca064d24a0e42d93dc2da901ec811324c04d2ccc6a229/pyobjc_framework_medialibrary-12.2.1-py2.py3-none-any.whl", hash = "sha256:4d69f910f17bbccb4f815b171270b9279f9d7526b318cf45a7b2ddc84fc38d22", size = 4381, upload-time = "2026-06-19T16:13:36.34Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaplayer"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/b1/eda7f1cbdb98a712239ea1a5deb12821d07055e16c51e8c25167fc801578/pyobjc_framework_mediaplayer-12.2.1.tar.gz", hash = "sha256:6acead24bb8f12e202976142db656c553b4a25ca2348165c35ce02862a93757a", size = 42670, upload-time = "2026-06-19T16:21:04.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/ca6e7b7c3827c3e835e81fadc7f3a26dd774a7a80fea7fce1cbd1ca044cd/pyobjc_framework_mediaplayer-12.2.1-py2.py3-none-any.whl", hash = "sha256:d37f5ede14fe70c547eac4abb49c9c96086f99acf8236985acadfcb07c851a5b", size = 7200, upload-time = "2026-06-19T16:13:37.48Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediatoolbox"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/61/4970e65b4efa1aac9493dbf8420fcc5d053433bf21c19eeec6cc7c8f7fee/pyobjc_framework_mediatoolbox-12.2.1.tar.gz", hash = "sha256:f8757deb15870b7543e2880aa4e7bd248fbc92f6a55763a99fda3703b1b1327d", size = 22811, upload-time = "2026-06-19T16:21:05.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/25/3b6de68c2441d9b5abe78af9ffdaf581a2f4c7858c28516950c14bb73c28/pyobjc_framework_mediatoolbox-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0c5047e20a1affe434a4aa073ae9c1baea2b677f37a537b2dbe4d8552bc8f82d", size = 12686, upload-time = "2026-06-19T16:13:39.785Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8f/9ae04dce47a830fa5c0a43b23188f482694f1bc74bf77381888c08ac731e/pyobjc_framework_mediatoolbox-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2b4f70f6760c5cf49654f6256877e9875423507764af787c770e09214e5891dd", size = 12841, upload-time = "2026-06-19T16:13:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f8/f17e483d63424753f56b397bc93d510035b3bc5a579896eb127cf817b7a3/pyobjc_framework_mediatoolbox-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:53be99e67f027fedac2045c4efac256725e1f6a122830aa4733fc3db608fe014", size = 12854, upload-time = "2026-06-19T16:13:41.706Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d4/afc7d67f91f5efbc3d4885ad2e4ddc2598a500f15973936df47e6c8f4b88/pyobjc_framework_mediatoolbox-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6f3a58249339267f5c40dad9bc945642bf5fa167a9be74353f5c76ef42ed4510", size = 13440, upload-time = "2026-06-19T16:13:42.607Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/6c/ecef85b04732a39865a61687c42537ae1d27119f91c586197d196db1cc89/pyobjc_framework_mediatoolbox-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:082c54423dd1080ce7cf9595e73997c6a0ef2e38c15be34ecb1e9a81163e9180", size = 12829, upload-time = "2026-06-19T16:13:43.722Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bc/97daef9ff7c2d8bcd67c4b8b52f117872f7e9b5e3c4cd561a0c2eebb770d/pyobjc_framework_mediatoolbox-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:88618fa1c1f0f5cd03ec349eb6e864b88fa3f7b88014299cc77cf56de5d4b3f4", size = 13438, upload-time = "2026-06-19T16:13:45.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f9/73bac498691fbb324cc4eedd6ada07e19f4d3f57c45211a7ce54f56a4989/pyobjc_framework_mediatoolbox-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f3b71021c5416c58d756441eeb52f5153ae696fe7ff50b1e470934ff947c1a05", size = 12843, upload-time = "2026-06-19T16:13:47.373Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/37/b6799c5892247a6c5f3b2be13cb8c90ae3cd8d8d115c764f159714ad3689/pyobjc_framework_mediatoolbox-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:a2ff7b9ada192d3d949ddcc2d52f2149ce812ceb97fb5f1f67016cbfc7929d03", size = 13463, upload-time = "2026-06-19T16:13:48.496Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metal"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/46/5920d6cb66cbbe298744889b10b3266b1408ad823855f55cdcb967c0d51d/pyobjc_framework_metal-12.2.1.tar.gz", hash = "sha256:cd362194bdb7fd2a9116b8dc1e6b14ce19629136304cdf6b88d105a969fda72c", size = 238139, upload-time = "2026-06-19T16:21:06.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/bc/fa4ddb10fbce1cdceb5fab0e1f2d5ceae90385f3ded8aec940da49e226f1/pyobjc_framework_metal-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:add59e48ca823d60bcf7e026baa2a95203b88c796b5febc140924fd9e5eb5821", size = 76004, upload-time = "2026-06-19T16:13:50.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b4/a56f0b69cd0ba016da9f2ab64776950a7ca8d7dbf7a4e03b1bdb2fffa947/pyobjc_framework_metal-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:92b1f2e8f4a86bd9ecf307144e1f2c5ccc451fc760534833ddcde58d7624c695", size = 75923, upload-time = "2026-06-19T16:13:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/6a6d547f11ea81d4ee1570d4092947d264e60f02288c119f14332ea3298c/pyobjc_framework_metal-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f39a87b50408afbfc8a78be0c0d164016f114c2f807eb35506051660b386931f", size = 75952, upload-time = "2026-06-19T16:13:52.471Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d5/0001ccf5217cde46c61140f062be050d6760359d2c4bd652b619cbd4361f/pyobjc_framework_metal-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:eb247c22391706162bcc14e6fd52101e632a51f3c0aeccb59cea549c019303ce", size = 76508, upload-time = "2026-06-19T16:13:53.398Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/e2d652df1f5604549a346f5048243d627cadae3a18e7491999a045f08f28/pyobjc_framework_metal-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a842860779c2a1c82d80b3800009b4604448d9635f1a69300393184b378cb6af", size = 75961, upload-time = "2026-06-19T16:13:54.466Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e6/fdf12a3cc476a540e064f409ccef28db80fe6bd01b652c9a7c9529869517/pyobjc_framework_metal-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6bbfe26a9d4683d776aeed28ba725102328ef5072eedde4c4df15df67b541c80", size = 76569, upload-time = "2026-06-19T16:13:55.386Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/21/236462c59d7b781705bdaa79307be1d952fed48d6ad561278167b62d5712/pyobjc_framework_metal-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e1be254400cc4038474466ff343093f8955925281f1e1209054d2fff9d6b362d", size = 76073, upload-time = "2026-06-19T16:13:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/32/8e/8deb988841348b718b9168559b393a25e60a3c70d6f5ca0efbaa6285ad38/pyobjc_framework_metal-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:9f69b2c846014b19f1a7180b33fed0acf670d72b7e44290018b6bb7fb39d607e", size = 76710, upload-time = "2026-06-19T16:13:57.391Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalfx"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/64/e64620b99d5fae9aa933e4d8189889275a89e4918773af64ea30b202aa89/pyobjc_framework_metalfx-12.2.1.tar.gz", hash = "sha256:c146060268f8c2941dba7695bb1511145035a8468b65d88a668b2eeb4ac8ea07", size = 33394, upload-time = "2026-06-19T16:21:07.855Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/73/1a5a3b967513abf7b270b83c7e3e8cef511f45f7d3805341fcba653ddcd1/pyobjc_framework_metalfx-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c8b17729b04033eedc6fd915f0d1ae09d7065d1e1301857b6e2e56f97270c8f5", size = 15047, upload-time = "2026-06-19T16:13:59.481Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/8d0fe1c96e795e6ec5a78ffeb445e3651a3caed505d7c10e2eea67444306/pyobjc_framework_metalfx-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8c1b2b84cb3a2481d95c324cda82ecac6fbe7f6c6a2c05c960b956449cdad1ac", size = 15082, upload-time = "2026-06-19T16:14:00.439Z" },
+    { url = "https://files.pythonhosted.org/packages/92/69/97594e1276302d41ffbbdf065e4e4663fa34487749544f2a19ce3aa5eb46/pyobjc_framework_metalfx-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a4e6a33836b384f2627bb8c68f60365d85d135b6ecc4e3c63392c9ac30a597fa", size = 15096, upload-time = "2026-06-19T16:14:01.69Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b4/796b5f98983ab5354a145069dbaa3622cf57ffa238ce071ee75f717977de/pyobjc_framework_metalfx-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c213297c6738e92e2805ff6029c9b70c882c67d5799e574900941af2d02c13d6", size = 15308, upload-time = "2026-06-19T16:14:03.063Z" },
+    { url = "https://files.pythonhosted.org/packages/75/00/5e6263f04a058fac0a27bb3afdfae925b77c83aba8f116a06f4e6f2d0d98/pyobjc_framework_metalfx-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:74ead433904ab845442eeb992a4eb13274e8c411d4c2605b62f623c8b6f04f53", size = 16370, upload-time = "2026-06-19T16:14:03.867Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b4/5f0f0937fc1ccf42651356bdd8c437468b6b312b6a3cc775c1e3293dfaab/pyobjc_framework_metalfx-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:976c04c1f76ae75f7556c0a82082948f6879ff4f6d026a644b507ececc2c52ab", size = 16615, upload-time = "2026-06-19T16:14:04.814Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/af/a635b139be334cca2c488dae9c45cba5b242cbb33d4962432a99b3aa5d45/pyobjc_framework_metalfx-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f2f7f4c01571031e289d3ad1d9c5b5eb5cebfd7909cb4cc17fc39b696b97fa39", size = 16372, upload-time = "2026-06-19T16:14:05.936Z" },
+    { url = "https://files.pythonhosted.org/packages/46/2a/d0fa22d9a13784626e4cb51d0d331766beb2cf9df7fc003acd17ca3f34a4/pyobjc_framework_metalfx-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b4a8a02d165df8be14ad51b8503415bc5d70ecffe3c8f86536166490781e5f93", size = 16605, upload-time = "2026-06-19T16:14:06.977Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/9e/18cd38c650176a9e4895f5b461c843e90fd85004a379fac799b710e813e4/pyobjc_framework_metalkit-12.2.1.tar.gz", hash = "sha256:f2f8e02f4ddeb1d49a5b3def09eddcb8a718289b6ed635fa5f1807165969e798", size = 28180, upload-time = "2026-06-19T16:21:08.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/be/a318901b833d9c84d2aa93ed46cd7efde582be33de1286f96ce6d57b99d2/pyobjc_framework_metalkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9ee027e7dfa9d5146a4032323f025c66051d0487523457975e05d97e62fae263", size = 8779, upload-time = "2026-06-19T16:14:08.907Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e4/4b96ce6a2e396c4ff3d509d0b823a23765b03b5bf3608308b21023308822/pyobjc_framework_metalkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d81f90237743cfb7a65e92d8581d0298feb4d59a20b3995321bfac9eca458f6f", size = 8800, upload-time = "2026-06-19T16:14:09.924Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0b/73b19059dd6b638a9850f2e2d350e3dfc7244fef9d89f84fc079ae06c558/pyobjc_framework_metalkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd09232de0cdca092a79efa4e73ea12357b1db862527c9ce8172d0c2b688c5c7", size = 8812, upload-time = "2026-06-19T16:14:10.681Z" },
+    { url = "https://files.pythonhosted.org/packages/29/20/1df8c5a560709a81848b6098c99a761813aac3f29defd4847766649dbb25/pyobjc_framework_metalkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a90f5ade5946194025bbfd2981a4099062d671ab2667c95d6ce218c13cc3d032", size = 8969, upload-time = "2026-06-19T16:14:11.501Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e9/2ef3900e36b165267007204bccd093389ba373439699c6bff85e6f9000eb/pyobjc_framework_metalkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4666993edc519a447e7c2dba75a90afee9597d6e583e088c80beae725669e5c0", size = 8870, upload-time = "2026-06-19T16:14:12.295Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6d/4fe11d7c809a5a019d048f0f5ba36222fe6d137c44859c7558d3b8f04a08/pyobjc_framework_metalkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1e549bfce38973abbb8df8332696d0bbea1fe990068ffa96e300c45fe6375ee4", size = 9014, upload-time = "2026-06-19T16:14:13.095Z" },
+    { url = "https://files.pythonhosted.org/packages/94/dc/af9224e90acc2a463dae9e3242fe75d5097e40771803914844cb97c77be0/pyobjc_framework_metalkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:21010a4f50e58f2a494df6325027539efdde53ff211ef5dc9f1873282652c117", size = 8869, upload-time = "2026-06-19T16:14:13.863Z" },
+    { url = "https://files.pythonhosted.org/packages/05/53/e3c2fdce9766d684152093cc86449268030cfbd8e23224dec1dfaece0d44/pyobjc_framework_metalkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:837ab5e81b79db0e7c01763a9ed1a21fa57a27ee4ecb7376b944a92036733e09", size = 9006, upload-time = "2026-06-19T16:14:14.744Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshaders"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/ff/6938291dd5a71e39f6948037dbb271993d86a3ecd7706e7cc38034feeaea/pyobjc_framework_metalperformanceshaders-12.2.1.tar.gz", hash = "sha256:a4395f8619ad6f1d382aab5cf116e058b18d3646bec6b730c77daa8f692b5de4", size = 190474, upload-time = "2026-06-19T16:21:09.743Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/b0/ed310b3a4cf06a16ca1e71c943c01955d734db172df043debf850ee719c6/pyobjc_framework_metalperformanceshaders-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:521d6a3ab80d76138754e7a1eaf02412d0d7502f5d486b4c3b7548d193b90457", size = 33927, upload-time = "2026-06-19T16:14:16.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/1d95d7a2c2855f9afb7a27378940f52ff87894d98e8bac6e98cb3a0099f2/pyobjc_framework_metalperformanceshaders-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6c679e85a4197302bdd7f9f9b17448c4df5c9a66e3ddb2d371814eb84a45261f", size = 34184, upload-time = "2026-06-19T16:14:17.743Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6e/40590459842bd635d0f5e77a520aca827af1331ef70e02955965f5122749/pyobjc_framework_metalperformanceshaders-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:856aa1b620ec04e64870694627435547affe350bda9e00e877e72ab518aec76e", size = 34198, upload-time = "2026-06-19T16:14:18.583Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/0f/f311b511eea76eaa7195164ea82133591c614bdbcf6efc069ef863dc0fa1/pyobjc_framework_metalperformanceshaders-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c1b094b81d0ed3f72b9345e7e4fbc47604934325d3695b4b8f2457701cf90fad", size = 34398, upload-time = "2026-06-19T16:14:19.437Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d2/999932228dcae4c691b295a5fb4bcd71abd16ac8dfbe67ceab629eb69582/pyobjc_framework_metalperformanceshaders-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b96cac9d50a9bf72e2bc3e006eac5ec0e7aeaabb65eac620df830c35af9b1fef", size = 34264, upload-time = "2026-06-19T16:14:20.364Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/46/96536afd54579814f2ceaf5a91ff16ae38e20cde7d630e45623171e7164f/pyobjc_framework_metalperformanceshaders-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1449836ff40cbb04a00c72b1c6219571914d895695d6d310bc1433b0181110d6", size = 34469, upload-time = "2026-06-19T16:14:21.265Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2b/4913eaf6eb59f20566f73b9f1b2fe0559aa610c6f8027e6ad20e9fa306f2/pyobjc_framework_metalperformanceshaders-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:db8048e5d7cb8a94b352f3902e330cf0f4de3c103ea07c261bcb495ee2b4ae7d", size = 34285, upload-time = "2026-06-19T16:14:22.184Z" },
+    { url = "https://files.pythonhosted.org/packages/26/fe/db17f4997f342d645b9ae30ec4f542f02612bd56496184a9294fa697c70a/pyobjc_framework_metalperformanceshaders-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:76e1b5f6733f14eed200631f6ba0af187fa89623cb1dcb126bf55dc4eddeba86", size = 34500, upload-time = "2026-06-19T16:14:23.12Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshadersgraph"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metalperformanceshaders" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/11/15e3acf0636f9418384cd3e213296ad9882f546889865913cfaee2339ed6/pyobjc_framework_metalperformanceshadersgraph-12.2.1.tar.gz", hash = "sha256:656e70c86645814ef1d02bac74933eebc5ff6427100bee4a3bbffde921020ab6", size = 60199, upload-time = "2026-06-19T16:21:10.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/d5/6aa84d1d976ba8b97cdc6486f09aab85f20ea6ba5079086f1de4426cbb2e/pyobjc_framework_metalperformanceshadersgraph-12.2.1-py2.py3-none-any.whl", hash = "sha256:9ac2270c573e9399c02196ea1725bd3c7ed3699d71ee70286b1f78beb8afaf5e", size = 7134, upload-time = "2026-06-19T16:14:24.104Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metrickit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/5d/1e0662fc1af513a08474ab7b9193012899e6930a490aefd9c2c531862a91/pyobjc_framework_metrickit-12.2.1.tar.gz", hash = "sha256:096878f3e750d12a7018b07ff3468d405ab3ac108f1aa92bc3123fd06934e344", size = 30581, upload-time = "2026-06-19T16:21:11.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/17/2a09f83953f702afa498032f22fa710bc17ae8055a6a82403e83c53f53b4/pyobjc_framework_metrickit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1167de9dfc42fddcdb0529b419d499b7c3e68c3f8f2828f93218360c9aaa0cd1", size = 8123, upload-time = "2026-06-19T16:14:26.1Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cd/e70cbd2ade0daf4e8130af6bb4a45793a077d7b064bb3fa04d4f65349936/pyobjc_framework_metrickit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee7253c6451b99f43588be83460bdce90c1c2f94e10fe6cef294d0d44af771a7", size = 8141, upload-time = "2026-06-19T16:14:26.994Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9c/651e524176ebce5eff66bc237212949ea247478849ef53308cae5ed8eb75/pyobjc_framework_metrickit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f6c2cc22017377e984fbea0ea6ee15b3c0fecda7fcc42e88d0beb5387ad3a4", size = 8150, upload-time = "2026-06-19T16:14:27.732Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/14/96162ec3e8d8a8131e86ea8459cd8a2c7ec6a28a6ac703d3cf7d6d11b710/pyobjc_framework_metrickit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1357f74151b851760b2520f20ffab69a6a85ed3c1aebd61164bb67e0be417375", size = 8292, upload-time = "2026-06-19T16:14:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4a/6c6fef775e75785277f2511bb76f95b4b97edba7389bcbe1fbff68b526ef/pyobjc_framework_metrickit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:dbabe6b44292b0dad3998921c46a4292e328b4ac0ee26e25f34a2eb9fead452c", size = 8208, upload-time = "2026-06-19T16:14:29.334Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/68ced20b5005f8856fabd93c65bc878e041a99c155377461519b4027742f/pyobjc_framework_metrickit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ad3a56006b975e0165eb34853e30d6d7b68814b39e7a5bfd02a20cd47234535", size = 8353, upload-time = "2026-06-19T16:14:30.134Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3e/a399de9fbbd3f58f6b2b63648c455225f6777182456ebf489fc60b36970e/pyobjc_framework_metrickit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:cd58c762d163a557d18b23dd6e856086902258afb64064b3a72fa8237144b3f0", size = 8203, upload-time = "2026-06-19T16:14:30.893Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4f/81f2d04fdf116182364e69c2b11f65e4dbef0e95f26150225efce9622297/pyobjc_framework_metrickit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:72b0e04337f4de0a5bf29aae719713265f255d3440dbe7338b6aae92cfa414fa", size = 8343, upload-time = "2026-06-19T16:14:31.707Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mlcompute"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/2d/16412fc8454bf987c64d7eb18ee0548198b35aad03b4d3cad6047fd18545/pyobjc_framework_mlcompute-12.2.1.tar.gz", hash = "sha256:4ee00b70d549619d63961864d9c2dd93b6db18d1c920242ae961517be7074f84", size = 55020, upload-time = "2026-06-19T16:21:12.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/9a/f7c94f4ca691822916509a260d9a18c58224b14845ae7dc7c2b56eb0b376/pyobjc_framework_mlcompute-12.2.1-py2.py3-none-any.whl", hash = "sha256:71517c5afdba1213aa4a832fcf3bc1cbe0efac7f4a42ea10cca33bbd4ad1db45", size = 9644, upload-time = "2026-06-19T16:14:32.481Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-modelio"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/a5/fbd7e593d0bf0f611b91758a855d1cad14b08f81609a588ce354b5677795/pyobjc_framework_modelio-12.2.1.tar.gz", hash = "sha256:d3706f803dc325c38536fb43fbd4174e958a95f92312a684ae152186661dff2b", size = 83795, upload-time = "2026-06-19T16:21:13.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/8d/64adc4f64bbb3517fe6951d9928aaf9fd4875e1f71b170de5b3348a4cece/pyobjc_framework_modelio-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5c035eb4598b61508d7180e8326f426918028ef7c8ba2ad933d29f343e9860a5", size = 20499, upload-time = "2026-06-19T16:14:34.513Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/acaef170056476aca099d56ec837f6f7bdc73c52507f14e577c8f14cb922/pyobjc_framework_modelio-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:82343edada3bb065317774a0f58c65f516fec6247113091da7029d06ad7e8431", size = 20511, upload-time = "2026-06-19T16:14:35.344Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a7/6c23682a7b986165d6949e70d0cf9c30d1ff22ae369711b23699f22fef37/pyobjc_framework_modelio-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68b53d1aea59dcbe5682f753ded2d3dc4d54598f58a0defe9a1d3219c7a801b0", size = 20522, upload-time = "2026-06-19T16:14:36.155Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/1f/d3c3c89eb0d10b00ed139a4308a3d5e353663c16310628d69d1fae2b774f/pyobjc_framework_modelio-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1714a43c35bd4254f5fb51bc5d6b67dfcb2a6b20ff309d34ddd22f03bb1709b8", size = 20759, upload-time = "2026-06-19T16:14:38.045Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d8/a50f8972c14c06a39bd25f28d87490ac6c8bcc1ca81f2237859d784200be/pyobjc_framework_modelio-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0dbf08b900703cc0a6d4e53b10da5d334dd5fed26be010aeda5eb53f93287ccd", size = 20494, upload-time = "2026-06-19T16:14:38.873Z" },
+    { url = "https://files.pythonhosted.org/packages/af/40/89e31e57a16cf9c11757f310e7cc2ae031008fe9aee5baca89f17c521335/pyobjc_framework_modelio-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:32b361d7b80c9b63271c205860bb1961b530f1e79b43eec21e970bdc48497633", size = 20743, upload-time = "2026-06-19T16:14:39.754Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/52310f780e2564103cea0d9681291529b588cf7b0065bb43bfda9dd239c8/pyobjc_framework_modelio-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c3d780628dc0ec585ecf845a8271b0843c619d50b6dae8335cdeb4c0a4054daa", size = 20483, upload-time = "2026-06-19T16:14:40.585Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d8/bf3bf64b81f53f604d94bf190c2b3c2868636d6dcf28ca49bb08cd34dd38/pyobjc_framework_modelio-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:476aadad72bebb9df752651ee2097e620a52e2293dbcd83dd9c0e424d7f401f7", size = 20749, upload-time = "2026-06-19T16:14:41.441Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-multipeerconnectivity"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/5a/cf3fad5f570ad3aa43010ef03e948d4ac1f0a531d3b7d822f1c19004f59a/pyobjc_framework_multipeerconnectivity-12.2.1.tar.gz", hash = "sha256:06f9a354ef0ef77c45c98ba9ef92bc48961522d7b3ba322e56b4ee3d4a46413c", size = 26450, upload-time = "2026-06-19T16:21:14.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/a3/5edf042e97873d983da1509957667557aacf1750afdbd60d6e4dda055b51/pyobjc_framework_multipeerconnectivity-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:449c3e35eba88fc58e38fdf44e1afc41449eb7eea8c2c1120d19491579be1a70", size = 12012, upload-time = "2026-06-19T16:14:43.31Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2c/3b85949975b600497c7f1f928e2f35344b2b2654550abac1f07d83c0ee89/pyobjc_framework_multipeerconnectivity-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3180c51bb68ed87f53e7b805f3443a510d7db00a1c0344223eabb384123fa0cb", size = 12028, upload-time = "2026-06-19T16:14:44.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6b/546137c9aa171232ef6912f90bcd2cb2b4705d8ccc81cd498885d284d862/pyobjc_framework_multipeerconnectivity-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e566a2dd4ac9b95cc8b4739092501413a1d697a1c34126dce489cf55c0c71a53", size = 12047, upload-time = "2026-06-19T16:14:44.828Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cc/519061d373de8c779487b978eaa48cf60d9ec588f6dd2924dc9faefe8ebc/pyobjc_framework_multipeerconnectivity-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:87049bc0af02bb623bdd90573a6a2abaca7c967520db81477b05d0c38860aa37", size = 12229, upload-time = "2026-06-19T16:14:45.57Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/b0/1899d7b277df12d9c1ff6e21465881ec85e7ccafd76da2fbe4440a7d888b/pyobjc_framework_multipeerconnectivity-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b1f0f3bc2dbd15e2231d9b5427c4224428660c1a96a66f2521a859b0c5888aea", size = 12024, upload-time = "2026-06-19T16:14:46.37Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/df2767d489c6083b11e1e3e4f4d60a3993649d378e876a551c7e911f1918/pyobjc_framework_multipeerconnectivity-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f22051fcccbbd16b9a1d4e2f161dc06304f13444ee65035e62ca6ed58a5150b1", size = 12237, upload-time = "2026-06-19T16:14:47.129Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e1/7a6f71aae1c8dfbb87baf9d1072df69570604ae735d7b3140ce00e4a68d6/pyobjc_framework_multipeerconnectivity-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:92f2a113f8ef13b6faa6aa9c95e01b29f10bd30c4652dc074fff747f8b29bdf9", size = 12016, upload-time = "2026-06-19T16:14:48.015Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2b/e9b6864ead5ef7435e30628185ab6908ebb85cd63c3c2b3f7fd788035912/pyobjc_framework_multipeerconnectivity-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3c49e75d0dc605394422ce9e869784c3f911551733044db09c77659de1280880", size = 12231, upload-time = "2026-06-19T16:14:48.946Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-naturallanguage"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/12/de013ac3cdbdb3cc616dd373399df4eb34b4459f668456d81f7062bd49c4/pyobjc_framework_naturallanguage-12.2.1.tar.gz", hash = "sha256:fa2d9c7040dcbbe4c7bc83ddfb9e3da20edb49824de8c78d3574aec7065c4043", size = 27243, upload-time = "2026-06-19T16:21:15.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/5c/3c0692cc72de5b9cc6e55d262df6630f43040374eb7454382473067d3379/pyobjc_framework_naturallanguage-12.2.1-py2.py3-none-any.whl", hash = "sha256:5eed3750f7cbd6a9584f2b9942c4b26b7134ed15dc044815ac79841403048be9", size = 5460, upload-time = "2026-06-19T16:14:49.857Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-netfs"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ad/28624d75b8339f70fc51bbac131d160a92b87c41ba5684a904304f8a6a09/pyobjc_framework_netfs-12.2.1.tar.gz", hash = "sha256:312b3a6ebcba6b3a03bdc7412560d8ddb5ac336c37a1205e32c6b58d831191f2", size = 15153, upload-time = "2026-06-19T16:21:15.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e7/6396d25cbfa2237784ada5bcb870531be597b9dbf1a5c5d41d007921d2cc/pyobjc_framework_netfs-12.2.1-py2.py3-none-any.whl", hash = "sha256:04f8f1743f98af10d005f42ec30b26f147d3ee0365b1ff3df2babaf456c75e07", size = 4182, upload-time = "2026-06-19T16:14:50.78Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-network"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/32/6a69c5ccbaf38557f6a090b565ea12a773a64f3f29e87e625c03fa46c183/pyobjc_framework_network-12.2.1.tar.gz", hash = "sha256:0cbb405f304f25617f138a2556433e22d4f706e558a78201957f9e2ca3c9ae21", size = 62791, upload-time = "2026-06-19T16:21:16.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/83/b1ca408d1057c7e84e791ead11a365a110f3872d83c8f19ce1857994e908/pyobjc_framework_network-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2009d4aacca836bd6b6f0aa0b503cfe593488ed55b62d1e5d6a051b7f843f9e8", size = 19627, upload-time = "2026-06-19T16:14:52.858Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c8/098f41c92c847c4c7f0f3efa1bd243555926c34df95dc39d2103bc178710/pyobjc_framework_network-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45d0ad8977ac71624bb6bbd929df8768a39fc8c13e97712bd7d37a4b9b4061e2", size = 19652, upload-time = "2026-06-19T16:14:53.759Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1a/4580c0fc4433a9761812cf392b93d7c874be1cb2b34f52c6169621bc284b/pyobjc_framework_network-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ff15672b23decfd9ec9a0051ccd15f4abf098020c4700ff8d2466e597e747eb1", size = 19666, upload-time = "2026-06-19T16:14:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/00/724d2761f1af78b5f108804bdd68896a6d260fc472856c444dd495afef5d/pyobjc_framework_network-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9d2df906f6cb262c74ee6b28f80856eea52d07723c325a04e804357b77c9a335", size = 19735, upload-time = "2026-06-19T16:14:55.656Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ca/36fde1adeb34d7e5000808fcbcab985b78810dce8ee803edf9fb4a73bf45/pyobjc_framework_network-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8d84a21895c3ecbbc48d683c7210c0bd12259a3e97cbab16af125248abb3fab4", size = 19396, upload-time = "2026-06-19T16:14:56.623Z" },
+    { url = "https://files.pythonhosted.org/packages/39/bc/882f1c507d512b7cffa39af8bfe4556d2b83bebf5be025e8fdcf21752aec/pyobjc_framework_network-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3a27d2276da4e3bb1e826defddf6b09bd8fa80fd045d3a711bd429785df8f5fd", size = 19453, upload-time = "2026-06-19T16:14:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/17/33/f7f7a3de02f8369070ebfb79261fdf1df3c1857476cd9b10a43c1b73e50f/pyobjc_framework_network-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a9484c5acd6507a7924307239de798aa1d56d35abb5d08664e9767411f40f9c0", size = 19405, upload-time = "2026-06-19T16:14:58.262Z" },
+    { url = "https://files.pythonhosted.org/packages/11/da/7bdbe57f1f288929502226afbdc7bb505ddc49c53fbcfbf47352fc77ba36/pyobjc_framework_network-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:3bcc2d70564c0d3c290be0f2be4c129bbeda18ac963f0513f6b5d8e482e1d2c4", size = 19462, upload-time = "2026-06-19T16:14:59.187Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-networkextension"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/38/7fdd6bce0c65c4ec01662e4489950b712034faa5adb59428a13ce9d56b0c/pyobjc_framework_networkextension-12.2.1.tar.gz", hash = "sha256:7858164a3e28dc81d317412123fcd664424da9afae63036e31979668ecd5972d", size = 81345, upload-time = "2026-06-19T16:21:17.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7c/5f300ebc1d2bde42af0fad1830cf221ee5ccebba0eba3e568daec1cbc352/pyobjc_framework_networkextension-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:190db4aee1316c9d3d4da8e7a8fb44b98b70a6f6930f69baf7c9258082f7fc63", size = 14457, upload-time = "2026-06-19T16:15:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e9/084b993f44295a3c7a95434d4e655050655a6fae17d8488aea6ab9c65bec/pyobjc_framework_networkextension-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb4c79aae8bd30099a2373d379a7d3cbfc6c210fbcdcb766c58d209dfe710062", size = 14476, upload-time = "2026-06-19T16:15:01.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/26/09becc50d9ca9a00dde6ec835b3b49249b006bd162bf40beb05661897330/pyobjc_framework_networkextension-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:94e851bdcd902dfac889daa5017bb9e3bc7086332956d9ecc53ef087d332d1f3", size = 14490, upload-time = "2026-06-19T16:15:02.7Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f9/f1aa8f1ec246ee79018d068beb38a25af39287c671f471545216e338d695/pyobjc_framework_networkextension-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:812cc5a68e464b1a0047048a46e0f1d44718cc39c37ab9d8d2827c34a37cc2a1", size = 14637, upload-time = "2026-06-19T16:15:03.586Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/4e19d49b25a7797c0720755dc7cdc4e54098fe92b128401f34c31ab59a65/pyobjc_framework_networkextension-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e7c43d18132a7140bd4cd8ff81977a3844579020dd22604f06684d0aad667c45", size = 14552, upload-time = "2026-06-19T16:15:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e5/17af4957cc34ba654d61a435bd028cc95253c45d6e1e480cb9b294a75089/pyobjc_framework_networkextension-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d99ac04d1fb84ef4593ee4eb9a18d80e9f7dc687ed642ead6a67ec4cd1ac9fcf", size = 14692, upload-time = "2026-06-19T16:15:05.342Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4b/ae571a55431fb97f7930c42a62fd84aba12ceabf7fa504b01d18fc5f9abb/pyobjc_framework_networkextension-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e639073b2d2a825af35ff7db046e0fdd969707710b4a77c184e203fee65e5c12", size = 14544, upload-time = "2026-06-19T16:15:06.177Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/08/ebb145dd982e95cddbcb66c9e2bb9e4a238212f67cb9e6005b2d3570eee9/pyobjc_framework_networkextension-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:2bf7bcd4712ca3636933f64e5c8fb2f72c5854a7cd6c20738ab88831e37c5922", size = 14680, upload-time = "2026-06-19T16:15:07.03Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-notificationcenter"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/22/6e5b84c0b0b187525fe655508adba71fb208abb747326f2a9da84dd2d6b3/pyobjc_framework_notificationcenter-12.2.1.tar.gz", hash = "sha256:952d0bfff1653f16f9e79336c8eeb928ed517f0212c914191a925a85523b5af6", size = 22159, upload-time = "2026-06-19T16:21:18.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/f6/1f09a8c541da1050c911bb292574cefa60deb23d29c0663badc6b7718f8b/pyobjc_framework_notificationcenter-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:40a1a0bf0057d6ec1567b58947e6b3550b13ea5cffa721ad63b1c713a73276aa", size = 9881, upload-time = "2026-06-19T16:15:08.914Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f3/2e870eb44592692ff85e829b28f2004eece7e1b1c4578dfd715251649b5a/pyobjc_framework_notificationcenter-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e86691f099a752a625b1a03a42f8cd8b28705bae5cb9924c988a7a8bc429d5c", size = 9900, upload-time = "2026-06-19T16:15:09.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/27/a56dece1c44638a8736a0878c8b52b153940183781a6065ca80fd38644b3/pyobjc_framework_notificationcenter-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:72187126a81e4a5f1fecab21b4740628dc6fa75a6a0471a0c115adfb49c04893", size = 9916, upload-time = "2026-06-19T16:15:10.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/37/1acb093763b4b83de911f53f28363bd4a81190511f7794235dd279d850d8/pyobjc_framework_notificationcenter-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c61e2dd16fe34410d972c57e62c6c4949f86e97b12fd1f1079b75ba409df7837", size = 10114, upload-time = "2026-06-19T16:15:11.543Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1a/fb2f8fe66035c42b05900c8533ab4674c56696d180ef6a6f84387cea95dd/pyobjc_framework_notificationcenter-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f91d2354beb4c928f4feda65bc2d73166aff1865a5bdccab2719744398c8d2cc", size = 9983, upload-time = "2026-06-19T16:15:12.391Z" },
+    { url = "https://files.pythonhosted.org/packages/54/fe/ea0cb8dc6771235db520c8ebe2e5899b6c45a835cfeacd82b324b6a5130e/pyobjc_framework_notificationcenter-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:65de365859ab6e87763df7fce64f141d1850e5f23ec88649cf4b0071900a8183", size = 10188, upload-time = "2026-06-19T16:15:13.312Z" },
+    { url = "https://files.pythonhosted.org/packages/06/52/6692a17ccb5f9b124f1c2a1f9dc6a4cb42d267d5478c0e8f4dd5a930538a/pyobjc_framework_notificationcenter-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:a3c19ff09ecb73f55a94a45b4004795d60027e0a05dbfb7212e5e8c2855aa9d6", size = 9976, upload-time = "2026-06-19T16:15:14.127Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5b/4fd8da648e6712d4c3558042c285cd1bf36b333dcc40529725487220145b/pyobjc_framework_notificationcenter-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:047ff96770aaa238bdce7f5ce73d954a1b0cab83cbff64188f92e852ad46c112", size = 10177, upload-time = "2026-06-19T16:15:14.953Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-opendirectory"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/02/df1979038cdc426990b364b2307ef33f5a6d915e70eda4791daf692024e7/pyobjc_framework_opendirectory-12.2.1.tar.gz", hash = "sha256:1b6dc2eea7857f05063f22e746ae66e8a2a135e41c62b7f3ca7c91f8a5ec5de0", size = 69907, upload-time = "2026-06-19T16:21:19.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/2a/e4bd17504ad233a38ea2d73a2b9914310c489a34f71418962bf99ff35799/pyobjc_framework_opendirectory-12.2.1-py2.py3-none-any.whl", hash = "sha256:2604cd01e236a1237ee6e52c689e60fb380807c5bda6981dab37dd14d89dd254", size = 11939, upload-time = "2026-06-19T16:15:15.771Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-osakit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/41/0a010e6e48e5bb248a8c4d6b7f71ecb1cf17c92b194db512b536f60a54a8/pyobjc_framework_osakit-12.2.1.tar.gz", hash = "sha256:6656e6dab5eb2b571cdcd0d68c0084fa2ac5f85f2f06423e132b410c44e87187", size = 18924, upload-time = "2026-06-19T16:21:20.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/ff/ba06033f6b8b5a43a188c810c4439a35cbc0baf90bfa90e4a1682260c1d7/pyobjc_framework_osakit-12.2.1-py2.py3-none-any.whl", hash = "sha256:00c1996bde228324665795f9fe9e129eccfbeab1c10d8ba34e1b1adae379b482", size = 4166, upload-time = "2026-06-19T16:15:16.725Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-oslog"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/3b/8a38104775d9472cc360018ca358325135779037122813f5d4cf0f1ce4f6/pyobjc_framework_oslog-12.2.1.tar.gz", hash = "sha256:423e19e08d3f01f3b0d53f2b4503322c0ef9d116c0a1f91fe36273232cf0ff22", size = 22322, upload-time = "2026-06-19T16:21:21.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/15/94c87fdaacac513dd737d86873e5c85683a4b2d247b86b778b73c11e533f/pyobjc_framework_oslog-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f54740a9a37deaa197b0af793a7fa0ecb909131199278ea00e833b2350516f06", size = 7889, upload-time = "2026-06-19T16:15:18.584Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c8/834e7bef1853a936a4bdb019f6e55f985ee3bd04ef6e7dc2a6f1a964e144/pyobjc_framework_oslog-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6cb3738d55676285692108f6cd43773ad9589030bda1077e8ff7080e44e635d0", size = 7910, upload-time = "2026-06-19T16:15:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/91/32/f6dc6ca6d9487e9be095193740263e59b700a239dac6b6a3bd75c30d7449/pyobjc_framework_oslog-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0ab4755e4b31d304d8eb04291470a7381d69b0381cec02242bdf37e2a492438", size = 7922, upload-time = "2026-06-19T16:15:20.191Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/937982d62f343fa41a3b0ccc3b481b73f804a04e185ebfd15044d21529ca/pyobjc_framework_oslog-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bf2a170e8fcef12de89749f085d3ef52f0a3a7084a566f244377012301d91c63", size = 8104, upload-time = "2026-06-19T16:15:21.196Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c1/12795679095752db88da5d3ac93d7e767b8e35b8a487a64405232fbf49f9/pyobjc_framework_oslog-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d16161bf907569eb02be4e0e4b515cd1ec52da4aaac7e4bf825d2853fd2fc2de", size = 7965, upload-time = "2026-06-19T16:15:21.978Z" },
+    { url = "https://files.pythonhosted.org/packages/07/82/5e6342650a407fab78cd20bdd4f94ae165eac8b951263f34a79c544999a0/pyobjc_framework_oslog-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1253dda3bce3ab7174ba215f011cad47e11b43c8406edb09e99bb122b34af021", size = 8168, upload-time = "2026-06-19T16:15:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/56/a62a21f3125117ba54c2da16db061bc48037387ccea2a9f962f065293985/pyobjc_framework_oslog-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c2fb370aa829850de13643191ff26a1a23b2d5b77649e883b274607866e417af", size = 7963, upload-time = "2026-06-19T16:15:23.859Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b5/47330df78d9ca18fe2ce003ca1a76ca4341be98b263d879c80683c980c7b/pyobjc_framework_oslog-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5b4bda2651fc0a5ceeb28e8a82ddf5ad23bbe86b9feaf9df8f10c3d283d4f9a2", size = 8167, upload-time = "2026-06-19T16:15:24.677Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-passkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/b9/5762ada91652118bd08b4bd236e4cff00edf5211403ee49cd8563a2330c2/pyobjc_framework_passkit-12.2.1.tar.gz", hash = "sha256:28de8925d89b705b9344e59498d15e5a10935e982b19eed10f0d498c5e670e7b", size = 68251, upload-time = "2026-06-19T16:21:21.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/65/8e8a038c97895a1f88593894b238663df1d21a4563a06fdc531e53914c04/pyobjc_framework_passkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:730c14e62f822053ed4502407da3b563bdaae0b55d1177ae2b12526fc2be90cc", size = 14456, upload-time = "2026-06-19T16:15:26.519Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b4/6f1fa4a3cfa23baef9eac38cf2df7b8dc8f64f99e0796c77cb909a6d95bf/pyobjc_framework_passkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:85df88aeba17f3aaa86f4eae1f0cba99ada8c18df7fd1ca49548276399417e26", size = 14472, upload-time = "2026-06-19T16:15:27.47Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/3500af51c2758b71cd2e3835a08df33cdce6b5c72b8275f7e1d776c0b610/pyobjc_framework_passkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:28e1c22d9476cdafe7839f368fd6e8c99f4925aa85e4f9126e5921f4c7e834a1", size = 14485, upload-time = "2026-06-19T16:15:28.371Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2c/addcb03ccdd59685043af645974d56aeb9867ac87a9e29acb0cbfca88d97/pyobjc_framework_passkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e51509baa9f4883b1583c410dfcf8b68372a4457e13cd57f4c9490c6e9895e06", size = 14651, upload-time = "2026-06-19T16:15:29.194Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7f/85a5e3c85c1e152d73b8e820d2ddcd3d9bc7d9aa339a32f2e25a14892862/pyobjc_framework_passkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6edade68d8c530e7fdaa7cb888899e8e7466b976e5736980136caf6b39903e2a", size = 14492, upload-time = "2026-06-19T16:15:30.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/eb/1c21b7018b1a62ff4c99498253f1a0e9d4d9fe28c43ce8c1c5fc713c0d46/pyobjc_framework_passkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:872c816839d89097fcdbf60c5a22ed277277d299d0ebc4db3b598702c750f22a", size = 14650, upload-time = "2026-06-19T16:15:31.242Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/eb/eb100daa0f738eea6e89efa365af68ca2d45934d1dd11a383c31b61cade5/pyobjc_framework_passkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:71805f7f9ee46976136b11f4563d490dd47219472f1648c3aba8a13e826ec1de", size = 14483, upload-time = "2026-06-19T16:15:32.312Z" },
+    { url = "https://files.pythonhosted.org/packages/19/43/c696150723da6916f03172c3cbdd1bec6e3876844de913f92f698dcaafdc/pyobjc_framework_passkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:50baf3bad86dd86c8f9e081df408cffe0830b18446775afc32acd69146560500", size = 14648, upload-time = "2026-06-19T16:15:33.285Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-pencilkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/6a/f8831e5b5bbdc3e999f3bd95c7e297bd8d8641ec3c1fcd153c77616e0e2f/pyobjc_framework_pencilkit-12.2.1.tar.gz", hash = "sha256:2545561beece43d63c745b6bbc4503cc7c55ad0792d4206916c75da26a4dca49", size = 20110, upload-time = "2026-06-19T16:21:22.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/c6/eb126b4b6e93ce53ba1451b04fb5a7724c9569e8ff185d34c56ebec869bb/pyobjc_framework_pencilkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:d8214b76615d7f0fb6295ee21c679edeb889a03f355c1774f792dfb93bd313a5", size = 4266, upload-time = "2026-06-19T16:15:34.139Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-phase"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/61/1ecd9506eee8698ab1156a7d99980d668e22b73cde9638cec98cd3d610f4/pyobjc_framework_phase-12.2.1.tar.gz", hash = "sha256:31392185ec0d3b0c5974c9b71f0c540843b1bdd884819484e627c6c0d592388a", size = 40754, upload-time = "2026-06-19T16:21:23.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/b9/a09f9ec64fc04cbaf2070055fa44d03454f6592328493b940fd1496f4560/pyobjc_framework_phase-12.2.1-py2.py3-none-any.whl", hash = "sha256:426b407f9ff0fe2b55128e3c0e9a949db4b0a909ca095d65303c247865961dc2", size = 7211, upload-time = "2026-06-19T16:15:35.089Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-photos"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/cf/af57f3b72daec93cd92b091473cac35f7616aeb2db5e4ca3a25c984aa5d1/pyobjc_framework_photos-12.2.1.tar.gz", hash = "sha256:e405e612c48563609fe32da9aec9286ed8cab10e226dc58ae6910e141fc46f44", size = 58673, upload-time = "2026-06-19T16:21:24.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/6a0ba1d041a1efa978244a6f74aa03247ec73621728c0df77f49a822044a/pyobjc_framework_photos-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6f90b2ae5080a8626d13e995334ed2e7fa0cf04bdb479d50f18398baa657c701", size = 12513, upload-time = "2026-06-19T16:15:36.972Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cb/b141cb95f75e94578e28062a033b4ae3bacb5a0660452e04df728a8b8d25/pyobjc_framework_photos-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:516320e2d3ab7c73bb196f7eb46afa289654829013ae79a51d663700e15ddab0", size = 12549, upload-time = "2026-06-19T16:15:37.983Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2f/599c2bcddbd5514b0a670a022a27b60c04198eec91eec025b25738ae71a4/pyobjc_framework_photos-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8be8e21b65627b4c55367c51258c22f7d73d3dbf7412a341e49684a1da1b60bc", size = 12561, upload-time = "2026-06-19T16:15:38.754Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cc/a1c26f3dcc216f3973c1fa7bf19d05f995db70a783790ff682ef96f77c83/pyobjc_framework_photos-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:060ff64355662599bdc1413601c04f1e7d3b8b318d92dec9ab72bdf1cebc08fd", size = 12743, upload-time = "2026-06-19T16:15:39.565Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c1/b17e9fed6c94b52bb00d0916638be9e47b4e32eecffb33431f89951ce6ce/pyobjc_framework_photos-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:423d8cc595912f3e3d7dd0b24809e171ba51d5f359f05e604d1bbc1aed7808a7", size = 12610, upload-time = "2026-06-19T16:15:40.445Z" },
+    { url = "https://files.pythonhosted.org/packages/96/73/0e8de5913643a0370c9089e9ce7cbd5f84da384bcec9426d164f0d92aa67/pyobjc_framework_photos-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7438abb6354b1f34c58804048ac26fd57a8084ee6be283d6e99827c940c31b7a", size = 12795, upload-time = "2026-06-19T16:15:41.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/57/6780525cd80cf915aa958ba917da2f1ffaf27c8964add3548db6deee1b8a/pyobjc_framework_photos-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:c49b8515e34b685c18862b68d04978378cfe29dadcc72d2d9af92054758ee629", size = 12607, upload-time = "2026-06-19T16:15:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/16/f102112441b5ff4f8abd4ef023a9d09f0de9e5ed8a31b8f7b86b73147d5a/pyobjc_framework_photos-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:9a575225535e90715488e75c343183044459dba13920651e283ea52f102715c6", size = 12793, upload-time = "2026-06-19T16:15:43.008Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-photosui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/e0/5e8aa49c3fe59572f9097bcea75844352c33c88fbdfcc518c6eef7657c88/pyobjc_framework_photosui-12.2.1.tar.gz", hash = "sha256:cb37100f2c75640d036a9fecf476a6fb68d1cafb5878c0e3f7c47054a63218a1", size = 33856, upload-time = "2026-06-19T16:21:25.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/4b/e3f11f8cfa520535f3c2d62c43bf5a6492669ee49f8136d87f591de62ab7/pyobjc_framework_photosui-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3589035bf9ca764f5fa1d09bdec976dc5e2f25956ab4ac080a453ec93896fc52", size = 11782, upload-time = "2026-06-19T16:15:44.851Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8e/66323978657e7cb281aae60eb7d4cd1738c495b04b1e8a435cbbbd02dc00/pyobjc_framework_photosui-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a8f0723e75c73d1ed3a29f3a6d374ce2275cf95d32aa8880e1bafe90a0354462", size = 11804, upload-time = "2026-06-19T16:15:45.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d1/8ea0b4977612dfa496c73a08feeb197b9016c702e3cbf19360cb0268a9d4/pyobjc_framework_photosui-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:03ab0b9d9dcf3e50b62f8579ee11592d0049044044ec1a2b5eebce3e75d56893", size = 11816, upload-time = "2026-06-19T16:15:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8e/d68e34582ba82ff27c4d7e1b64332bd7b76c51eafed29efaf7f8944a941c/pyobjc_framework_photosui-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:872af4d088ded84a2a4cbc07aea10d98746221409d3179474e84c1a45f5f871c", size = 12013, upload-time = "2026-06-19T16:15:47.391Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9e/12605c68e8dc2bd5564d2d5122eef304158f078247e51cf6b666d9420bbd/pyobjc_framework_photosui-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e9f68423c00f418c1d0a27ca6c86f81da509d25490efd17f274d2d37ee569999", size = 11812, upload-time = "2026-06-19T16:15:48.271Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cc/8ac06f3f49b82e23e3bf37fb4bb9838cee7b99d44496d524f0cc29ccedd1/pyobjc_framework_photosui-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:bcdcae68c773736c8171486c608df427f0bedfd6e80ec81005cadef28ae8b349", size = 12001, upload-time = "2026-06-19T16:15:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f6/34665725e0f6fab6875213abf4ac6267db3ac1511951388ce84d63790baa/pyobjc_framework_photosui-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:e3d2b4446a9b818abddad6d201212ee8fbaf699632e857bc255dd98143cbafb4", size = 11811, upload-time = "2026-06-19T16:15:50.073Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ea/4acf8e674823bf6f01f89599a50cae87249398ddd1d173979a23ce5440a0/pyobjc_framework_photosui-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5f8560bbcec3b81755be8b4cf78fd38d81914ef6f7cd2d4e74c77f8ee3848a88", size = 11997, upload-time = "2026-06-19T16:15:50.9Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-preferencepanes"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/f2/788a198c7b8c44a27c2b358c2cd846bbd97bb6d9c8c457cb248c3c0a8958/pyobjc_framework_preferencepanes-12.2.1.tar.gz", hash = "sha256:1b8e839b364b792441201c1112e17cd6d42f493987169da04ec65eda365d2ede", size = 25113, upload-time = "2026-06-19T16:21:26.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/b1/bc42da075faf6e4201bfe2ec4bfda95b71877a15df4a501977ef739b7128/pyobjc_framework_preferencepanes-12.2.1-py2.py3-none-any.whl", hash = "sha256:026ff87afba2d381e3d9dadc58957580558e1a705291da6794107220a3cd8102", size = 4829, upload-time = "2026-06-19T16:15:51.915Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-pushkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/dd/d0ad735548407e862717b7ef08a29dd51b3b9c1c1987ce43f76c25d72c34/pyobjc_framework_pushkit-12.2.1.tar.gz", hash = "sha256:12800cf33aadfdda5df3e487d4ce3d8a79a2a0efcebbd5b1e11a1ff8a1a4067c", size = 20464, upload-time = "2026-06-19T16:21:28.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/79/a3a754ffee2e97b20fbd0956fd3cb686b38eec771c6434d2311cf10631af/pyobjc_framework_pushkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:49262afcec0cedd434cd3d5215d343bead702706115ea00892f776777aef2cc1", size = 8290, upload-time = "2026-06-19T16:15:54.784Z" },
+    { url = "https://files.pythonhosted.org/packages/52/80/366a0f1210c433857f0639b040e643fc31accfaef38ab2ab5f6ee93733a1/pyobjc_framework_pushkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:675f65d1ce111debdd3e371a6e50296ef9345d8123311c658f16f3e9bf8cb106", size = 8305, upload-time = "2026-06-19T16:15:55.606Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/bf/69a637549c72fc4da253a1319e1cbeb13b0abcbdb24d09a3c21ddcb031a8/pyobjc_framework_pushkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3feb1c38ccde8e24548e5a5032d5adc2cb354f1aaa0c7ebed6babd2fdb86cda", size = 8326, upload-time = "2026-06-19T16:15:56.429Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f9/28b5c789ec9167435f0a095cecab27230e41496c33c0a458df546754a2eb/pyobjc_framework_pushkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9dd060c626f17365803f5dbffe0ceb3062e3710886ee9a7c887f3f70b3285802", size = 8460, upload-time = "2026-06-19T16:15:57.351Z" },
+    { url = "https://files.pythonhosted.org/packages/68/68/8eea4540ff3201b1fb0e6301655af3d8e92293e3be23343cdbcf77b7bc2e/pyobjc_framework_pushkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8ff35a63097b6b7268cadc7cf7754f5d966296847e0b084a8aa9716f86d05cbc", size = 8381, upload-time = "2026-06-19T16:15:58.276Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ca/4ece7bbf8f62acae3f4d0ad46f2b5867f74b8d1c04e4d136b4a2b5058ab6/pyobjc_framework_pushkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:53928c675b70e71f2e68cb7732e7cf114c1f17ef80bcdb0fdf8060e69ca7239d", size = 8515, upload-time = "2026-06-19T16:15:59.086Z" },
+    { url = "https://files.pythonhosted.org/packages/81/aa/18ae91101a5138b19b8773e1d5ceba9d58f9e1964e75cbf9ec917db8a4d7/pyobjc_framework_pushkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:60457988a79883028b3ca5f6e8cebc7051f553f34e98ed16c8a1885d01c46de6", size = 8372, upload-time = "2026-06-19T16:15:59.974Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3e/9ee2507c94e80d05de593cee7e0198027b066f255af8701fd4481b178aa5/pyobjc_framework_pushkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:92413a410fb59f8e6b2c7a3c2c4b35721c2245fe4d5afe94cf5c7db065372916", size = 8520, upload-time = "2026-06-19T16:16:00.885Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/08/527d1ff856e2f2446b5887be01989cc08f9adaf3de7d4eb13d07826c362f/pyobjc_framework_quartz-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60f29408b4f9ed5391a29c6b63e2aa56ddfb8b66b3fb47962930427981e14462", size = 217998, upload-time = "2026-06-19T16:16:02.978Z" },
+    { url = "https://files.pythonhosted.org/packages/14/fc/d7c7b3134cdbd1a487f3f77b5be125d87a6c9e7d9411035739d99335cc0c/pyobjc_framework_quartz-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:de9c8cca7e95290c8d540466af11c7cdfe3a5458e6f56c34006d5b45243f9ed9", size = 219000, upload-time = "2026-06-19T16:16:04.29Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4b/861f91a1565d3189ee899e177b915551fb9a7e2ca25414025a8974f04e74/pyobjc_framework_quartz-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:54c9bc7f507192691841ee4eba5bf36990b259df83ac728efed2d7ea1cd021e4", size = 219403, upload-time = "2026-06-19T16:16:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b5/b27010d2f288737f627f74be6d5549f49c841542365c84b9a3011fe39ce7/pyobjc_framework_quartz-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bfc0d2badd819823d21df8069dcf9544ce360ed747a8895c51bdb25d8d125f45", size = 224458, upload-time = "2026-06-19T16:16:07.252Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5d/85ffd9d433989205d572a50d625c63b29c05e0c5235a725f15ae1023672c/pyobjc_framework_quartz-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ceb56939c337b36d9d81185ade31f77dc52c85cf79bb16e53e9b32f54b6bb3f5", size = 219769, upload-time = "2026-06-19T16:16:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d6/b917e4b63d72ea84a27121076f3033f23f6497c0e6ce8d304766c899897f/pyobjc_framework_quartz-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8105c98b798f2bf81c05c54bddeeadbf62f0b5dfec13bd6e719dd2cdf7e1cddf", size = 224717, upload-time = "2026-06-19T16:16:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e2/f3c1ed3228f7430ef5ade23db6f1fcbae99290f177ce5653348fd9e05f4d/pyobjc_framework_quartz-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bbc214f1a216b5d3651bc832d0ac4589f029f3f37cd6cbb370aac12a7c77942c", size = 219825, upload-time = "2026-06-19T16:16:11.433Z" },
+    { url = "https://files.pythonhosted.org/packages/66/2a/2c99a5ad2fe0a11600ea123b8e9a08ff138fcb2ad1e13e376f4bd4aa1d96/pyobjc_framework_quartz-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ca61624a0b0e6286d8a0f97f47eb9011e4e81e9a339db436d48af527e7065bb1", size = 224770, upload-time = "2026-06-19T16:16:13.035Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quicklookthumbnailing"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/49/41d06038c50a750d6172b875d45ec8a180650b98c6e0d8cdce43b4120ef1/pyobjc_framework_quicklookthumbnailing-12.2.1.tar.gz", hash = "sha256:1b348b674569b8df40ef6acebbcdc4e7e8b347b0a437c824b35a6d6f91acc398", size = 15765, upload-time = "2026-06-19T16:21:31.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/1f/1a92542d6b2d879422a20c99124aad3d9e176a9ff65bdf0d1cecb381cbd1/pyobjc_framework_quicklookthumbnailing-12.2.1-py2.py3-none-any.whl", hash = "sha256:747a99db601e0a7ca48fbd32909c803f47211adc194a4c41a5b5430738b3464c", size = 4329, upload-time = "2026-06-19T16:16:15.183Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-replaykit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a0/2d5903651b581cc9c64cd08d67088310807a169e60465c46d016ac53e2dd/pyobjc_framework_replaykit-12.2.1.tar.gz", hash = "sha256:c5a712ff52ab58c58a53a27e47dba2d3823b13f2587a395855e9c4f0510af6a1", size = 27213, upload-time = "2026-06-19T16:21:32.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/6f/2319235ab2626251692091ebdfe9838863447014fca25a6e26677fab41a1/pyobjc_framework_replaykit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:07b4c27d67dec0dc68b0a352810d80fd95bd474a940bd0304ac182d39f9df664", size = 10143, upload-time = "2026-06-19T16:16:17.544Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c2/9e1c99f86d7a11925b0009fb9051bbd4f7e2cf512e8bb470131b9c87f79b/pyobjc_framework_replaykit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b682657b641df5a78195a8f8a7abc6be04aa445dfb73814c96a12d3f252fa5d8", size = 10176, upload-time = "2026-06-19T16:16:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/834b5e916fdcdccde827e2d5bb4137f5ae34b7e225cde1ed845f848f0336/pyobjc_framework_replaykit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:18d5cbdc48436f5f612f37163ab2315518220f88aae39d81c7fd1460da8ad510", size = 10190, upload-time = "2026-06-19T16:16:19.16Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7f/9b55c3b25cea2ee2506980b626256beff02541c978f55caf91f3643bff3f/pyobjc_framework_replaykit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:daaca45e9b94b2cdf6f76ecfdcccb51faf5342cbf8d7a4741ef361406376740e", size = 10368, upload-time = "2026-06-19T16:16:20.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4a/00c76c2b2274f96057b5abf8c4de903b2b358dd0d8a0c7a14a6b75cc0ebd/pyobjc_framework_replaykit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:70c68b9394ff0aa4c9bff16ce13fdef81bf778b07d85e6f01d8a39945d7d320c", size = 10243, upload-time = "2026-06-19T16:16:21.216Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f3/ee0da9e4923cc54068acdddec46f440c9627124deca9939cf2d506cb613c/pyobjc_framework_replaykit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:efaa9d6285774d69469b00fac76bed50cd3e300d46388329a67fffb5bbc745d8", size = 10438, upload-time = "2026-06-19T16:16:22.171Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d6/fb3425e69aaa8e6d9c46182220e5ed131d7ce0b11f708fd307779bb36f69/pyobjc_framework_replaykit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d48c5467c5b71d038b00e04106576741da6a38894b9bbb4e1f5b58f4116b7683", size = 10243, upload-time = "2026-06-19T16:16:23.151Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/51/96c871e6fa2e978cf0bc1ec06cf8eefed6db8ec8dc72b0d1469578ce0f82/pyobjc_framework_replaykit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0ea6641401a45197b6f5397f45009f504e15ce03c719c4455c38def2f915d86f", size = 10434, upload-time = "2026-06-19T16:16:24.103Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-safariservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/8b/638f43f5f7936dc3919fbb7a76a1efb3826941e49df12bbbb4b95342a594/pyobjc_framework_safariservices-12.2.1.tar.gz", hash = "sha256:5da28790b389efa21a33d2d48d3322dc3670077ec9c8af9054824d42153e0298", size = 27306, upload-time = "2026-06-19T16:21:33.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/30/32ac369c880023b529a617e69b831e912611888349d4b9f768fbf2ebc9d8/pyobjc_framework_safariservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:491a02a10332bffd2a081d52e3bb788819d411433ef03103cea144390025f56b", size = 7339, upload-time = "2026-06-19T16:16:26.048Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/c60149609a5f7dd91e35d43a3317ab9bfcceffba6780254533d42945422f/pyobjc_framework_safariservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:46779f1c6a53fe561bafb95379a7bb66535938e622a23b8308f4125f443fa81a", size = 7344, upload-time = "2026-06-19T16:16:26.825Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7b/15dbacb24573d8fbdbc80685c440c5506829c9e36dc48b32d4f515a0190e/pyobjc_framework_safariservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:210ae2a93175fff88ccbc6c50a58ff981158a2d6bfe4edaa1880aa2fc5f4ccc4", size = 7362, upload-time = "2026-06-19T16:16:28.023Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d0/ee671fef9dfba5fb54cb8f00dd8f80b907ffe39acbba7e4b89d122a7b420/pyobjc_framework_safariservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:98dfc05920eff91fa5db9cc64cf764be8b588ae179ecf33985fa7a9f81e044ba", size = 7368, upload-time = "2026-06-19T16:16:29.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d7/5edb0bd367c8dfd787359cc989a18e9224cfeef979808f61bad92a20249a/pyobjc_framework_safariservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2dbf52cd5c33e04b65f48891dbb1627612bb23e381d91161dcd53dc76d31e70d", size = 7394, upload-time = "2026-06-19T16:16:29.929Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1c/eeab5f53ba9d3901ab7ac045e6e4988a8b3284f2e87f8f3317eb82736136/pyobjc_framework_safariservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:05591b89870f2fbe77c57185eec3b21f08583193628e00c88b7173ba35a6c965", size = 7402, upload-time = "2026-06-19T16:16:30.896Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/74/f323de081cf336d5889a5ec79611073c3be3f3e0f0819214d7d9a9e59cee/pyobjc_framework_safariservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:d852eaa503a9031f5232418b38dc439013eeccd77131e3fddccf9e580be5214a", size = 7411, upload-time = "2026-06-19T16:16:31.745Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ef/c3e91e0829d045240b6ae00664da5346cfa26b98c3d3ac6a3ecd27a21032/pyobjc_framework_safariservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:53b7d50145705b7de5e19f44185a7f20f716921be2f7ed2cecc000cd773c16c8", size = 7419, upload-time = "2026-06-19T16:16:32.566Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-safetykit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/57/ec33de6440eec0c805643dec1115d7a0cc21be8e8e13dfff52e66de6a0e3/pyobjc_framework_safetykit-12.2.1.tar.gz", hash = "sha256:33defe7e4155dff6abf0a2990bb2a918447b9339199ca92c2f3f219d48189ebf", size = 20855, upload-time = "2026-06-19T16:21:34.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/76/1291e7ae26ae34c1228b4f9f86fcc85a5171cb5abd6eb937f137db353f74/pyobjc_framework_safetykit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9cee8656c9c2867f4d972efde8dfaf308176fdd881f807b49b616d37a58daf8d", size = 8587, upload-time = "2026-06-19T16:16:34.656Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/41/ed6f62913c9b3bf2259de53caffd58758565625e0c04f1d970644452b53a/pyobjc_framework_safetykit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f5e757c9565d104c442b81babcbc4998daf0326b14d928dfae42c5459580a309", size = 8600, upload-time = "2026-06-19T16:16:35.639Z" },
+    { url = "https://files.pythonhosted.org/packages/db/08/81833a95ca16ce0379bbbfb8f1524f2d862942457f9f6f05d0c5c1bf1b41/pyobjc_framework_safetykit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:eb272c4f8304fc2c8db9652020b01f2a6026c91fca59072189264d03894293fb", size = 8614, upload-time = "2026-06-19T16:16:36.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9d/6ff0294bfe087f428dd28861da0953c8bc7d0f540caf8cc4e724bc8550dd/pyobjc_framework_safetykit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0122066ee790375e97ef888af8134c13f00c3b890d44769c6c74f3b126438506", size = 8775, upload-time = "2026-06-19T16:16:37.789Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/db/1563ae0f10f4f07a22298383c6e176e443cb9666ab57c27798a8738b0b03/pyobjc_framework_safetykit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:052e4ca43b48856e32876c433c38590e6e668bd72bdfc820772b76188bad80e5", size = 8665, upload-time = "2026-06-19T16:16:38.936Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a9/5f74b8158bb7ae337f0d23e07303988120abf2c669bfdb4eaaff665f8436/pyobjc_framework_safetykit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7f048af0941796ef80627b88c1411b376ff9c0217ebac402422e1f3fe3a0b644", size = 8832, upload-time = "2026-06-19T16:16:39.942Z" },
+    { url = "https://files.pythonhosted.org/packages/21/94/b697512ea9e57ced080e2201cfe289dcd1c18e9975a1eb35353425f89639/pyobjc_framework_safetykit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:152d800a3b3755f45330582158e198edd6809be026b6e78aa1a858095edd3f69", size = 8666, upload-time = "2026-06-19T16:16:40.857Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/b1/c436e56d692afca134f641c4818f230e147c4bd16e3aee14fb9c6ac706fb/pyobjc_framework_safetykit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:dc1e4b65e87d6501c571752550d248853918f4141faf1d3c9e6dc41aca1b0862", size = 8822, upload-time = "2026-06-19T16:16:41.68Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-scenekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/4f/4c614327db5c8a9af6fd8995bacd5f4d3c331c1be66f29722bac3af594cb/pyobjc_framework_scenekit-12.2.1.tar.gz", hash = "sha256:9f5939ecdfa9c13347f6ab61173ba5eb386766cfebd82200fe7173f70aa34083", size = 132003, upload-time = "2026-06-19T16:21:35.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/27/ac8abf8c42aac47cf948dfec1746aad5e6b1110f2c11b6c45a82611b7f47/pyobjc_framework_scenekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:41d1c000f2cce780fdc18419aad0b1cdad50f49317b38dedf9219ce5bcc5a659", size = 34761, upload-time = "2026-06-19T16:16:43.637Z" },
+    { url = "https://files.pythonhosted.org/packages/74/99/4c880fe6fa3bfcf980566b8d6b1e608a586d97f43bbeaf658a2889cc1ef8/pyobjc_framework_scenekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a79aabfbbaba44098e5cfaec2f87ae3d04a31f1e250283dcf7ab08cadceed1ab", size = 34816, upload-time = "2026-06-19T16:16:44.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/bd/e87bc4fce0ddc9806f31eedeffb5c8b9b309888026faf3ca4d1ae7414ee9/pyobjc_framework_scenekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6de30a01c643892bc1fa5f3254c17351ec9c72c7ab9af9c895290e8191dc057d", size = 34842, upload-time = "2026-06-19T16:16:45.406Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2e/abf47653356f62712729828ee06a9bc1ee8c67b1e4bba96a37f0cfae39b0/pyobjc_framework_scenekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6cb7213c8f9c5d3a111b3850082f545001fbcea6173606e0986354350c83cbaa", size = 35158, upload-time = "2026-06-19T16:16:46.298Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8b/bd6d503b2d1b9809aa601424f9428bbc5814d19627e9bef24f9dd8d6669f/pyobjc_framework_scenekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd6c2b0b56a2487c7ea8f5e18cedeeef04e3c28b8fdd54917e8b8df45306d0c6", size = 34952, upload-time = "2026-06-19T16:16:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/08/11/15cef017994c8ada57aff1ef855cbd1916c1fd40725621e48cd7235a8ce8/pyobjc_framework_scenekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9e840a4b48bae1a135cbdce82f81ce1187ffd23e7eb2ffdfc84a2db5cb758fe2", size = 35241, upload-time = "2026-06-19T16:16:48.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/4fd8bf2a03d37a1f5bd3a2d2e897405033339ae4bdd1524cfcacd8cfe7e9/pyobjc_framework_scenekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:80b5768e346e5e2f9489a8851c0e867b4a8258092c2574e892993825763d3b4c", size = 34988, upload-time = "2026-06-19T16:16:49.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c6/9f70347af44836cc5e847be9597ce05c8a5f0a1423b58683d8f3567d4e96/pyobjc_framework_scenekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:cc7769ebcfa1cc17f3046220d2a06927d2429a5f40ccf66bcdfe2c23868ca8ed", size = 35276, upload-time = "2026-06-19T16:16:50.09Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screencapturekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/a6/b7e72e32d3334e13eae592cbcd9f3c060c43adf78ddfebd0eb9c6be0ab05/pyobjc_framework_screencapturekit-12.2.1.tar.gz", hash = "sha256:e419cbf9c2f9cbd172d1c6e5bc69a44e0a7d9e45cf43058d48eeda4f785ce860", size = 37840, upload-time = "2026-06-19T16:21:36.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/4e/020fdc67539a3b5879075b51ae052c97f9ce6ba4aaa4d37bc9be4d9fdf05/pyobjc_framework_screencapturekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d9be9def5875e800581dade26b45ef66c735c12ceb4a17c5457bebac159903d9", size = 11566, upload-time = "2026-06-19T16:16:51.925Z" },
+    { url = "https://files.pythonhosted.org/packages/55/eb/76a25a68695f8502ca17ad0f482ed3e8d1714a7fdaed86728388778510c7/pyobjc_framework_screencapturekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:407dfcd80e493d11ce54163d4cc973119f6a507cd695875f4cdbfde6f2db42d8", size = 11596, upload-time = "2026-06-19T16:16:52.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/c65ea6d42f9873ee6a1d63d4db1db334d60536ba679382688647bd626cc0/pyobjc_framework_screencapturekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d23bc1d0ac0068f328a97c1ed95d611cb2b8517c76345ddbbd21e5e8bc85a898", size = 11616, upload-time = "2026-06-19T16:16:53.772Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8f/b57ec1a7632d7d49f01fc4b322c2c81fe62757c5ad78bd19f0fe085b6aed/pyobjc_framework_screencapturekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3269ee9ecc1cde271cffb1e763672469b70375fb6aff00394a0387cc622070ae", size = 11794, upload-time = "2026-06-19T16:16:54.604Z" },
+    { url = "https://files.pythonhosted.org/packages/30/1a/efebaf2d5f48ecbd231b2b79df2be4c25a7ebe1804a7c36c3902acd81457/pyobjc_framework_screencapturekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1cc27066b907726389bde47aca1afd27c2af13c4eb88b40f3b813082987e01", size = 11673, upload-time = "2026-06-19T16:16:55.347Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/95/55ce785f8e619d4e953b3672ccb5b81b16b11c48509dbe38689426022b8a/pyobjc_framework_screencapturekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9d4493a95a5eca7b8d5287fda6b2614a1d62def22b24f01eb743fc371c018ae6", size = 11876, upload-time = "2026-06-19T16:16:56.285Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/f010d9fcb42fad7251a84b061f79b0347c23ee19789b28ac137373bf3579/pyobjc_framework_screencapturekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9f6041f81a7a9b4da29fb4ab1cd6912447ccf557cfdea294db3754898895d6b2", size = 11669, upload-time = "2026-06-19T16:16:57.114Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2f/720037603723ffeeb5ffbc1be47af1b1253647493ca245f01d457823b021/pyobjc_framework_screencapturekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:075f1faf3fb6239b104b2ef6f78f9bf5b0bac062aa48c560c9abfeb629282196", size = 11869, upload-time = "2026-06-19T16:16:57.89Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screensaver"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/32/a3826be36a6473c6bed8f3a7cbd879b8feadfd83463cb1ff615aba66e414/pyobjc_framework_screensaver-12.2.1.tar.gz", hash = "sha256:15eba02075a065283e763c8087b9c6fa565907c95e0575a383c1a6ef4c9b1868", size = 22814, upload-time = "2026-06-19T16:21:36.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/c9/a2ad7ca6ad84d8379e1604718cd63205454d60f0978ad1aef5b585fad6f0/pyobjc_framework_screensaver-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:be8df2ca5d4765d2d64f0c130f0a1d9a748c6d965e8a0b45fed2ff12681682aa", size = 8571, upload-time = "2026-06-19T16:16:59.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3b/126bc97a45a4bc359e26e567da2518c6b891e842c1061ed1f942a1341b28/pyobjc_framework_screensaver-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8f43926bc686453af7798f460144beaaaea09ffc296bf20d1b38c9e420f94b4d", size = 8492, upload-time = "2026-06-19T16:17:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/06/33c369a75297e3b86ae977d473d24d2e141fe0e5c6663ab829b9e5960509/pyobjc_framework_screensaver-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7535dec51e71d41bbbf2100f49b26f8539e34fb34ec9943d7f075b8ebd46b26b", size = 8512, upload-time = "2026-06-19T16:17:01.332Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/f9/2617d0713f2b49a7acd2977f6f0b7f1cf7eb57e0ed6666b56a7e7bd1d5f6/pyobjc_framework_screensaver-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3fe3232d9aebf919ca2413c373f96915e55b904a1ad362091e79d142e634841f", size = 8519, upload-time = "2026-06-19T16:17:02.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b0/7651f7bf92c24a218afa69ff7dbb515b6354e9386a21957c619c5f7bd471/pyobjc_framework_screensaver-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:367b252aefba2856d51d6b7e899770a8c4fff5bee6cc5487eab03f317e1b5383", size = 8556, upload-time = "2026-06-19T16:17:02.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/06/7235f5c2f6aed47b61c642341444d531db54baa1fe49ac02cc1169c8aec2/pyobjc_framework_screensaver-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e0311a13bc1408c1fc9d62e2f905aa5809ecbdee67fa8e5381c86364e012163f", size = 8573, upload-time = "2026-06-19T16:17:03.717Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/37/d73f9f3c156c87b1c2643e446ccc7bfbb2467d48c06324935840c545d038/pyobjc_framework_screensaver-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:8f9769b5e5384bc812c87aa4346766f34408ec8f5ae94e0c8e14202a71f90f7f", size = 8588, upload-time = "2026-06-19T16:17:04.525Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/fa/adf2f598fbfd5073a3e3c45221e5c7bf6587e45b4a30194531c1f539c4ac/pyobjc_framework_screensaver-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:45c2943314245929e306bd38a8ff92dbb18a6a7c5326b0e10004555fc1f86a00", size = 8590, upload-time = "2026-06-19T16:17:05.501Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screentime"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/93/27470ca21f4c596a0692a3e9cfcd45d38c3bab6f0566bbb5af4e3cfb8b98/pyobjc_framework_screentime-12.2.1.tar.gz", hash = "sha256:c97e700995c03183a1a73f2eaaf90f5ed66d68e8c2e40ff7ed2fddbc77ff7b2f", size = 14074, upload-time = "2026-06-19T16:21:37.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/75/d434c86454bf4c21855b69f145799699a2d1650067575c4eeeccc6738ff0/pyobjc_framework_screentime-12.2.1-py2.py3-none-any.whl", hash = "sha256:b252234f5f1e01d6f3dbfde44a6019169100c2337f24b65694ffdd6ddfaa3c4d", size = 4002, upload-time = "2026-06-19T16:17:06.29Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-scriptingbridge"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/97/908c6a8a4eb665c952dd8b6c670eb2ad40661c31721ed47470d1329115b3/pyobjc_framework_scriptingbridge-12.2.1.tar.gz", hash = "sha256:779b2238b33b61fb9ab4fc71d080e42ef7e27562506f5ca9d783effc4c769a5e", size = 21226, upload-time = "2026-06-19T16:21:38.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ca/27d6e825fb9ff1069ef94e8770d0851e3bce654b507c79c7dde39f81538e/pyobjc_framework_scriptingbridge-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fbf6c59d27ee1b03ae14cdc3fb7330c2d5cc1a2cebbc438744550131b3e6f168", size = 8370, upload-time = "2026-06-19T16:17:08.124Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/aa/21a22afd311b14ea317c09aa6b238232f8d45e7795005f032c97bb9816db/pyobjc_framework_scriptingbridge-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:89153d5bbf44b2ab5a63b646712ecb86b1a64606c3082934ec5c6be4c8a192b4", size = 8381, upload-time = "2026-06-19T16:17:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3a/7e83276e69d5dca85597dbb5129fafd1f453bcd9c44f9ef1996292cc1fbe/pyobjc_framework_scriptingbridge-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:093ae30d045bd5348bed5fb34c826565d0d385305fb75159b46fc2bc1d7d226d", size = 8402, upload-time = "2026-06-19T16:17:09.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/44/64b578077c04d505849bed5ce06af49ebb3a8cb69fd4d2eb0b97b0c9243a/pyobjc_framework_scriptingbridge-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2b620a2c3eccc446c21be0d93a343cdf709b1c300ccc8e83a4c0a7ba0c30e90b", size = 8551, upload-time = "2026-06-19T16:17:10.564Z" },
+    { url = "https://files.pythonhosted.org/packages/71/36/9257cef0ea8739fbcac8e21ee9bdaedf06632e218f3de09724498126b296/pyobjc_framework_scriptingbridge-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:57ed9cb870ed86a7a8bd42f1b418bbfeb5886c09a448429f190ea4bedd18bd38", size = 8441, upload-time = "2026-06-19T16:17:11.384Z" },
+    { url = "https://files.pythonhosted.org/packages/da/38/48908ac4804d8f324c8cffd9027744e231ff8ca97c51e63f270b202d8e4f/pyobjc_framework_scriptingbridge-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a0899b94bb908ac9bd0dcf1feaea545d1477ce7bcd6d6665e7dbb551a75c7339", size = 8592, upload-time = "2026-06-19T16:17:12.202Z" },
+    { url = "https://files.pythonhosted.org/packages/48/32/fc95c045f310d9d2bdf200cba3ad83baf9acaa373e1211d40fb6b5c849d9/pyobjc_framework_scriptingbridge-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:526bc671d9a3a401d3d310376f05503ae7f1381eb7ef1a274af90a8b6514e209", size = 8437, upload-time = "2026-06-19T16:17:12.991Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/26/49d0912123fa7744cd2a866b50197500676e2d4d5e9d190434739e7bdbed/pyobjc_framework_scriptingbridge-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:776afb47d013841b66c28c065a80863918b1530420db62db8e852247b2e0148d", size = 8593, upload-time = "2026-06-19T16:17:13.875Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-searchkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/53/be9909e2c3672242d5a4f8223a5132d39f3ae9e9b82062e214ddc4db828b/pyobjc_framework_searchkit-12.2.1.tar.gz", hash = "sha256:1fe1ceb2db1d8c86f75484dd9f88ac39dd3d2cffba250498ba0e2312435214cf", size = 31141, upload-time = "2026-06-19T16:21:39.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/d2/10e5fc076f236f96fefea233cd31eb15374c393bd8d737cb41b49ac746a1/pyobjc_framework_searchkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:936e41880d48da6742128bc900de37d14771e718087719589d589e858aa2ea60", size = 3760, upload-time = "2026-06-19T16:17:14.683Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-security"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/b8/4267b802d8dba6de468e7d0765b05cc4e146fa376ed9f55e0b6461016bef/pyobjc_framework_security-12.2.1.tar.gz", hash = "sha256:d7831b1537f4346892e7f2f0e2b09d79bee98919b0767f4061278d0e03028f2d", size = 181065, upload-time = "2026-06-19T16:21:40.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/ac/f2ff946edfaf16b4ce5e31afac5e519f83705c0f4842fd25134ecb8f2f4a/pyobjc_framework_security-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ce461296b003b2ba17c8b65f6339f9d2fd5dcfa2b3b52ddc0a696334cc8974c5", size = 41306, upload-time = "2026-06-19T16:17:16.816Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5b/2719bc4062e6c27083191fd20e365ae02d0bf1c22f4d1a88211e3d96b369/pyobjc_framework_security-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:76ff6e44e62d3e15651540493879bf16687d862c4f10f3cadade757811c8b8d0", size = 41300, upload-time = "2026-06-19T16:17:17.702Z" },
+    { url = "https://files.pythonhosted.org/packages/15/90/dccd4cd6877ef208957dc1f3675287d8614a4dcd2a3ee0a5e56f5fb5a1ba/pyobjc_framework_security-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:990013baba29d6f985d8950b23701129b2597b3d16f628b785fe97596d8a8de3", size = 41299, upload-time = "2026-06-19T16:17:18.511Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/af/f9e8040e0c3ef6a50392a46ad1df482a666aa615180d40730b00282ff81f/pyobjc_framework_security-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:066a3e5e9d368e7a6ba8dd52be2077a634ef12a54fbfcc78b3b8154a8f988a1d", size = 42179, upload-time = "2026-06-19T16:17:19.48Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3c/76e2a8bb8d5fe48f0e8e25c6abec1609f3667cc39935017badfe9e9603f2/pyobjc_framework_security-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:5319ae49b8874363ab51c6ff4d85d4ea0cfa6d836fe0306e901ba9ae560b880d", size = 41370, upload-time = "2026-06-19T16:17:20.501Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6e/7120956e9833b2c70757eec1f65f57c191e00662cf74c4545d88315643fa/pyobjc_framework_security-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:21618431e0dbfbd3d4029445e3118af88e5d7e52ddecf9a2d17c759c51628d85", size = 42926, upload-time = "2026-06-19T16:17:21.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ff/0bafc557523e5755f74dd5363386a1e9b03f611e2e36df0737a508cd5ab4/pyobjc_framework_security-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:fa192e9df479375e6242adcadb9a44f32907dd7fe1207608710cd3af65fe3c84", size = 41376, upload-time = "2026-06-19T16:17:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/47/33/33d266117e46fef148caa4f986b3d896cb9bfd76bef48bd761cb60c758ee/pyobjc_framework_security-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:07cd044a7996f9a897040c49055fa3bdf565acac4a25b834a72e60602376146d", size = 42944, upload-time = "2026-06-19T16:17:23.371Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityfoundation"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/9e/c1b6426d9ba602ceda4f5bf438705e05930d46c3ef561a89736e1b9cea51/pyobjc_framework_securityfoundation-12.2.1.tar.gz", hash = "sha256:b10f7c6f2fea27f105e69e0ef455df10e911748a4a414aff74f9dede48dd2cd3", size = 13103, upload-time = "2026-06-19T16:21:41.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/03/b439d6af2c215a59e71cdb2cf00959415f0dd1ec0fd84b0a517c403290a0/pyobjc_framework_securityfoundation-12.2.1-py2.py3-none-any.whl", hash = "sha256:4f3f52573805977e94f3b50af27cacbe2abdd05fd96fac4be746685e523e1e85", size = 3826, upload-time = "2026-06-19T16:17:24.38Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityinterface"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/24/5486d26d86abf4edb639de2eb5598b6c5cebe33a1aa19d55575694d72160/pyobjc_framework_securityinterface-12.2.1.tar.gz", hash = "sha256:08e58cc05741e8515f157854831063261a7247497c996a120f90148b8aa78842", size = 27798, upload-time = "2026-06-19T16:21:41.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/36/4591538165b110012f1bf442212404ae4af6ba3a4d8cb5a4cf7be611a00c/pyobjc_framework_securityinterface-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:db17172727a7799a38076b759c824b81ab5c2c4f49b8b71f4d6bba25f9697a7c", size = 10741, upload-time = "2026-06-19T16:17:26.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/46/8dcb2c1983ca1fcb8279de27264c4b5e00484caaf714c7b846c7800dc898/pyobjc_framework_securityinterface-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e15228ac342d553464f990435e81ee67c4f2fa5cca99388933cee72fd8764193", size = 10807, upload-time = "2026-06-19T16:17:26.996Z" },
+    { url = "https://files.pythonhosted.org/packages/19/13/3c18031c450eb8677f600f86af9c6569174d093dbf60af0bef202813b681/pyobjc_framework_securityinterface-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b93c778e431c0290b0eaeefdd0e9f502a5defa172a82710d697537a4ff8db7c", size = 10820, upload-time = "2026-06-19T16:17:27.862Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/88/da14ec8edd7d22245bf3230a5b2c0127a73b7b8ae5d036053ce16a722e0e/pyobjc_framework_securityinterface-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1bc4a9c50583bebc061b734e382389a50bd62ad5fdaadeb8585024278b96dea9", size = 11161, upload-time = "2026-06-19T16:17:28.683Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/e11a20ec8a2cdb15e9b0cc2dad354480ac92fdfb902faccb47500d5141b6/pyobjc_framework_securityinterface-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b427588d565fc4af5717e9ee2a017d01b6d8c22ba0b68799e2fe5001215db179", size = 10857, upload-time = "2026-06-19T16:17:29.465Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c3/3e8a084ceed6c2a8256c67e6bb167b8fbddb163465514dfae3ffbeca18e5/pyobjc_framework_securityinterface-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0351cf5555cb4d7d2c04a4cd8047611d76b015c254259832adf8cd416e3efec6", size = 11205, upload-time = "2026-06-19T16:17:30.221Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ca/9544778341cee37392614102156b60056a16237b1cc9d7dba55e9d523817/pyobjc_framework_securityinterface-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9970c0cfdf9d07335c9a6dc123893e430a9184e84e258e68878730ed9e47366a", size = 10863, upload-time = "2026-06-19T16:17:31.046Z" },
+    { url = "https://files.pythonhosted.org/packages/44/27/9206c1d8aec4f4a27e3d4d52bb138d46370104d48b008c8ae0825dd321c0/pyobjc_framework_securityinterface-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:258b237ec6f2efa13ea7518491c0d5d48092ad5c5cbfa9274a45ac303859339a", size = 11209, upload-time = "2026-06-19T16:17:31.936Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/f9/5aed7140a5f22102cbffad47e1f8a6cc231a428b2021a1731925da9a78f1/pyobjc_framework_securityui-12.2.1.tar.gz", hash = "sha256:87b07746fb9ca7634c3c74f89bf6ab90dffbfe0c0ffb89551aefce0e35353a50", size = 12648, upload-time = "2026-06-19T16:21:42.645Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/c0/b166bb5b4f5fa80dbf9c09074d435c41b04dc741f8a4cd37b241a2c884ce/pyobjc_framework_securityui-12.2.1-py2.py3-none-any.whl", hash = "sha256:e1e0d9ff4671aff464b7af48b1e10bf9aeeffc1ee40c91fd1ac301ab19d87e45", size = 3626, upload-time = "2026-06-19T16:17:32.783Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sensitivecontentanalysis"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/8e/50648c1e4029611acfa6a5cc6c20e3f36d9754414c7c9c690ef142ee1c6e/pyobjc_framework_sensitivecontentanalysis-12.2.1.tar.gz", hash = "sha256:e958e4333b72e7bd93a32be6c3118c50be8e98de6ca7a41bbf076a712ab2ca21", size = 14428, upload-time = "2026-06-19T16:21:43.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/38/ee90dce73e9eabcc5c80ee514b2affcc89dd3b47dfeaaaff20a1cb0b5e33/pyobjc_framework_sensitivecontentanalysis-12.2.1-py2.py3-none-any.whl", hash = "sha256:918c362c11673308191a9d94c2c59a368d4cc39e354694e1da5c99b3609cb47c", size = 4269, upload-time = "2026-06-19T16:17:33.696Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-servicemanagement"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/2b/289270180fc32c2297907e6576355aaabf004297d9830a62f9792a5bc95b/pyobjc_framework_servicemanagement-12.2.1.tar.gz", hash = "sha256:99ceee681fea1e57246d33acbe199100f2e35a09cac97ae1c271e34073c28763", size = 15295, upload-time = "2026-06-19T16:21:44.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/15/ba63887c27663a7107f289a44072c04c6b351b52177c63d8004640fa7325/pyobjc_framework_servicemanagement-12.2.1-py2.py3-none-any.whl", hash = "sha256:8c84c82a09bf00046ef2d43f910204cd362fd1eceb706176c30d079ee208f2ed", size = 5456, upload-time = "2026-06-19T16:17:34.619Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sharedwithyou"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-sharedwithyoucore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/85/8a2d509a27814d56e064f15469b8fd9720ce5c7ec669bcb0cf4b2e800b25/pyobjc_framework_sharedwithyou-12.2.1.tar.gz", hash = "sha256:b1908b9822244ea31d4d546118389c69687982e5fa67bc72cbf1a9e09f1f84b3", size = 27310, upload-time = "2026-06-19T16:21:45.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/9f/6b4f112d25e6f7b78e60b4caf852b197416e4e5fc399c33becb67934d77f/pyobjc_framework_sharedwithyou-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6bd370918c4cedff2a2f6e15e22f6184e5431bd4624b0d270d6e518b6ffec8df", size = 8817, upload-time = "2026-06-19T16:17:36.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/47/d9810da0987abdf3b21df2d8d872e46f4d916a5fa45ab43370136375a7ae/pyobjc_framework_sharedwithyou-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:32188fc96282ba4d3686587d200d5c0304ec3e0cd5cfbb8d0bdadc5ab1fcb300", size = 8832, upload-time = "2026-06-19T16:17:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/bf963d03e57084970380d99af331cf5b6d3cb214a949fd8d8a7f266edd5e/pyobjc_framework_sharedwithyou-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:927a95d78693f2b2323dbc117d1fcf638612cbfb19d2fd0f6077c19c22eb92cd", size = 8846, upload-time = "2026-06-19T16:17:38.044Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6f/56ac0ba0950a3e20cc9e8993432466241b8b5fbb08867840dd796cbd9f38/pyobjc_framework_sharedwithyou-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46d20007e80717f04506a7afee2b6bdcc5ca50a345d7a26fd3f0cd7d97e5cba0", size = 8984, upload-time = "2026-06-19T16:17:38.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a2/b8aba1597228ffad1fe1293bc16e7056b1d17d592794f369a9f0615bce58/pyobjc_framework_sharedwithyou-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:60c29e58e6cf6d760a337c6ae76186ae3fbe1dcec4877cf8c6b2827bcdd40836", size = 8894, upload-time = "2026-06-19T16:17:39.66Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c1/f60ac8d3ad890c5f25d784b277b3f6319dba0aa7cad711d7d0812c50a73c/pyobjc_framework_sharedwithyou-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:52470d61f146dd5783a8a69acdb114fe8e7dee4e7d6853ae214460ccee11e485", size = 9041, upload-time = "2026-06-19T16:17:40.635Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ce/2f743a3865b82d017ea8b6bf74d4b84fae71b01ac230544e19ad6f666ac1/pyobjc_framework_sharedwithyou-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f56137c9a1b53a69b76061c7cfe0f8739b5c42140891a326fd68b7d1e2be702a", size = 8888, upload-time = "2026-06-19T16:17:41.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ec/b33cbed5b00e5a8d158b0b32812fba1ee5ba6edbc96788f3e8a3ca316f61/pyobjc_framework_sharedwithyou-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:52d02b2188c9009946c3dbdb65db0b032a9a1546448c7f761f5be14d84250abe", size = 9037, upload-time = "2026-06-19T16:17:42.275Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sharedwithyoucore"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/05/5e9ba6cdde040717004115a1254ee315434bf7df5f2ee9f9f9ce619bf6dd/pyobjc_framework_sharedwithyoucore-12.2.1.tar.gz", hash = "sha256:b8a4d2d79702756d9fffc5e17f83b45d52c469579acde873a487842ac334384c", size = 24333, upload-time = "2026-06-19T16:21:45.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/e3/e234ad577ab3efe97a3a1b0703e57430672ed14a70fccf345601adbbdecf/pyobjc_framework_sharedwithyoucore-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ac0e9812f970bba7f4db5c6332c9282c1b32456dadc2c88c82165712af341b5d", size = 8579, upload-time = "2026-06-19T16:17:43.976Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0b/c26f3af20af44e755f33ba8c75a5439bd8e2fd4bfd406da1211fc08dd8a4/pyobjc_framework_sharedwithyoucore-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:26d3c00be64f9e422be6a902dd2e95532c7ef4e6149ef756dfc2811a71a1c6e6", size = 8599, upload-time = "2026-06-19T16:17:44.808Z" },
+    { url = "https://files.pythonhosted.org/packages/07/26/fd4dd0b314bbe91b58cdc30b0621a8c6efee2fa9a9a75a4f985d9f14b492/pyobjc_framework_sharedwithyoucore-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:25d42419c12d964bcadce37a4cc2e3825d5227bd1bf00767902a702136bdc1c4", size = 8614, upload-time = "2026-06-19T16:17:45.633Z" },
+    { url = "https://files.pythonhosted.org/packages/08/90/d2177377c80ab30c30a292686e84b298b09c431303fa0c26ebdaf9fd5cca/pyobjc_framework_sharedwithyoucore-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c6ca2669c6c7d1a061acbf0c12c55aac3848a43d580b9aa96ffea69d36985086", size = 8748, upload-time = "2026-06-19T16:17:46.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/aa/2878309744e21c37c66c72e1d1b3519888706220b8857253c6be54702efe/pyobjc_framework_sharedwithyoucore-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:803748c78c9b062cd0aba8205be6c178ce6fa2eb227d9ac3bf26b484cd2f4517", size = 8664, upload-time = "2026-06-19T16:17:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/f4c5764d5971fadc6d73c45d28d29ebb67086e007bb08bb731442aceb7f4/pyobjc_framework_sharedwithyoucore-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f991c7b52cdc831244ab49f76ec20fd331a561f364aa33ceadebc684e7fac7da", size = 8810, upload-time = "2026-06-19T16:17:48.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d8/cde9e276d2540eaf4d619a299c50c7b594c77ca0ac4cd68d341d308019a0/pyobjc_framework_sharedwithyoucore-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:f5544a515a902b796a22272fabe83a3fd39256de9cf243d90cfb7c02ec9e3f7d", size = 8665, upload-time = "2026-06-19T16:17:48.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/67/639e301589e643658c2e45d8312f31df3257205948f10be6c2e0fff4024f/pyobjc_framework_sharedwithyoucore-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0defd143c6633a4032e705a77c9c340bd11d5581bdc098e43455c35ea7c43e16", size = 8795, upload-time = "2026-06-19T16:17:49.618Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-shazamkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/7b/12a46aee28ffc14a5118ab45be8f0f629feece3548df81d934e31e723ada/pyobjc_framework_shazamkit-12.2.1.tar.gz", hash = "sha256:4cfa9325e381e8b365b2d4725b9165a5e52f7986f28dcf23c3e7f0bd3bddf3aa", size = 26062, upload-time = "2026-06-19T16:21:46.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/78/3ae7f591a3bf96ddc0c31fa9524fa495b1f51910a110cb6725d8ab6a0bb7/pyobjc_framework_shazamkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cafe6fdaa478611ddbea6be8fe01373bf65b57f54bc6ca7f8a5580b2f75ca7c9", size = 8639, upload-time = "2026-06-19T16:17:51.337Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/24/7e327525ed03ed041fb97c5f32bd9e0ca79bd282f50d373be68f8f71f14c/pyobjc_framework_shazamkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee31a56ae4d15401e10f79fa07f7f79c5cc747afa9a5ce581654f82ee5b3c6d9", size = 8661, upload-time = "2026-06-19T16:17:52.177Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a0/5247501e4d5482c0977025d9914d481ad5029f9f372a84475c01240940e2/pyobjc_framework_shazamkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6b5fcc07180a2fb5a1cef0f38cbdb24caa869e423f612116bc67135dee59b44d", size = 8675, upload-time = "2026-06-19T16:17:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d0/ad91bcaf2f43bbbc5a7b67cf1c0544e2dd875befb95664540346e9328324/pyobjc_framework_shazamkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0ccde3a967120d3285fcc40d48f34f345bc6f0b4accb4ff64799535030bc3e3a", size = 8820, upload-time = "2026-06-19T16:17:54.278Z" },
+    { url = "https://files.pythonhosted.org/packages/03/32/46d5a58ef0c0956586d7bee5ce846bcebc0d167ec353b6fdfbd7ec14b4e3/pyobjc_framework_shazamkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2d7a35d6e66e99b44810a3045c1922d3feaedaef546ccaf930c44312c1b83d3f", size = 8729, upload-time = "2026-06-19T16:17:55.104Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/aa19849a9ecb5f8db5d7e904826b78e76f6e1ef4dad15431d4da8243ab4b/pyobjc_framework_shazamkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:450bebfde1979e6776ca880c1765d9b9a2b08c4433301cff256bf20944541de4", size = 8876, upload-time = "2026-06-19T16:17:55.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/46/857e30042b4161eaa7169e17a77bec4fa61ed12fc69203bc3d0f3d74a427/pyobjc_framework_shazamkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:449d63cd4403963d3d1cdd6e56bea738367fc85bd8c3f861f81caaba05ca677a", size = 8726, upload-time = "2026-06-19T16:17:56.741Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f5/2c310004afd4f85d45e4bfc470cae6067a6c195fc2cf8a552de7d3fdecf4/pyobjc_framework_shazamkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:e429463fe172944232e95a6e2e7a22aacf09885423928574e868c5a0b20d7fe3", size = 8883, upload-time = "2026-06-19T16:17:57.613Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-social"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/25/0a3ba41ba7aa0380968854a53f02e549afe0b5af89856abfcc2f8988e050/pyobjc_framework_social-12.2.1.tar.gz", hash = "sha256:c2877c7ddbed8f3ea17065687725df57243d25b64beb3b885e8a18482c24bf7f", size = 13751, upload-time = "2026-06-19T16:21:47.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/81/91b2b6420d8c72ffae0df08249d3f5bf8f6f2a2ba2f4f90d071855d74913/pyobjc_framework_social-12.2.1-py2.py3-none-any.whl", hash = "sha256:3d76bce48e3eced0683096a8f8d32ba233c44db8cb9469f881a783932f29c2f5", size = 4494, upload-time = "2026-06-19T16:17:58.466Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-soundanalysis"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/43/b6a1644c01010c50dd4a69b0e4ed144139d60d7900edae937486c62af73b/pyobjc_framework_soundanalysis-12.2.1.tar.gz", hash = "sha256:d17bdea63c2b910c2046ba43383b29b82d594a37feee4431d45b55adc08a3882", size = 15777, upload-time = "2026-06-19T16:21:47.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/16/2e8f86936aea345432c6d0d080513dc53eac417f4a485d9b8ffb2d5db885/pyobjc_framework_soundanalysis-12.2.1-py2.py3-none-any.whl", hash = "sha256:4385f492320a304bf64ca772e4a5b29d796f0fc160ff764ed060ac1456aa3cdc", size = 4244, upload-time = "2026-06-19T16:17:59.484Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-speech"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/fe/0d1f1710d77deb2aefbdcca344b682f86277a0cf2df55f49615bdee213e1/pyobjc_framework_speech-12.2.1.tar.gz", hash = "sha256:77e01c6e92b34e3bb47dc5b0c43a59cb7941a7eb6ce595ca3de3a686a5df21fa", size = 27772, upload-time = "2026-06-19T16:21:48.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/8a/f8391a8daa0743ab652a1ef1666b62d1dcfb526ebce2254d61e6d7c76adc/pyobjc_framework_speech-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:481ab813439be28ae7b93dd9de4d5a52e5d7351954f1555489b3bdb635dd8243", size = 9279, upload-time = "2026-06-19T16:18:01.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/10/0415e5368531cec9274b4d028d2075a2e3b9752af8d6c75aec75603fbee4/pyobjc_framework_speech-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:20e70519b54b09ca3ded0bf4b19dace1d39847caebebebdc4381f127dc58f33c", size = 9287, upload-time = "2026-06-19T16:18:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f1/b89ca277820479cba6aeab75ee50357efa902ea4d4a6f7871bc66c1c7403/pyobjc_framework_speech-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:774d6d07193fb49ffbc5c39447eafca21ca5b2058ae41f79af876aa6cce5d726", size = 9305, upload-time = "2026-06-19T16:18:03.253Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/be/dc1620d483e55337a529982c04d58edba4f77ec435c9700a78319171bcaa/pyobjc_framework_speech-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f425a3a11c282dfbcb0b3f3e218f5f155232c94406b31ec395c40aa9e309a0e0", size = 9465, upload-time = "2026-06-19T16:18:04.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6b/426c949ab1a5bc59fa6fe90bdd20f59661a87816d75397787a00611ee0d1/pyobjc_framework_speech-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:64d44383fb9fac20f457e902e1ea4b680c871ffb9b3e88862c482dcd59da7df7", size = 9371, upload-time = "2026-06-19T16:18:05.035Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/00/6dd086d3b241648374314730f6a520e0cce309d581f9682a34d78613d66e/pyobjc_framework_speech-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:e646d8c781baf531e5943c2376c92ffeeb0a8bdf4f48d93f88e59b5033d12b55", size = 9525, upload-time = "2026-06-19T16:18:05.855Z" },
+    { url = "https://files.pythonhosted.org/packages/87/67/02afd94b537c9303e7a83da184d8a92fd7a41a50d0c7042ea7b0ea6e7f1b/pyobjc_framework_speech-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:6ef705bf457651ee3c0089a3c4a0a14d6241189f51a3255fee0424caccb9d9f5", size = 9357, upload-time = "2026-06-19T16:18:06.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c8/39fd8ac2922c78b092dc26c175c549e1dcd628f50b73f1768ce12be95997/pyobjc_framework_speech-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1f62eefa6b576f6cf0d558a6e9ee5a1e9f99c973f3bb0c5521a5d7a356db9e0c", size = 9519, upload-time = "2026-06-19T16:18:07.494Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-spritekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/0a/3da8666b42a696b1d82a283ba442f2941060fa304359d4855c3c6072dd3d/pyobjc_framework_spritekit-12.2.1.tar.gz", hash = "sha256:989a25cb2e9d45ecb97655f55464e44a342eb525a891e46a563aae27c683eac0", size = 83906, upload-time = "2026-06-19T16:21:49.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/ef/260a6deff24f18e68e776288346624e6c36c20e85dc82db74e844182b1cb/pyobjc_framework_spritekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a1744c4f79b33274c4957d609e8ff87a3c2920105222f4a38e6df870f5e8bc9b", size = 18584, upload-time = "2026-06-19T16:18:09.471Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/bb/d19a875a22e30759be9ec33c7f238126d14c5b9cde515fad9c708577585c/pyobjc_framework_spritekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:182326b96722731536018564a890fce1b6cd9860d5fde3e0c2dfe31c3108f7fd", size = 18650, upload-time = "2026-06-19T16:18:10.321Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e6/83366c41ed99c17d690aaf76574e083d885d00c96b615a8552f284b318df/pyobjc_framework_spritekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee809a16cb549197f124240d1387e0da8ad9dee9bd853ab302fd8538de2cc381", size = 18668, upload-time = "2026-06-19T16:18:11.573Z" },
+    { url = "https://files.pythonhosted.org/packages/05/58/76cb4ff81419708ef45095d588f9f73a75a7c6a4c1c0f3070f3ab981ae2d/pyobjc_framework_spritekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:780d80b09c3a5f368efd5d567291bdf52cc07da079e75260776904ff4c5bac17", size = 18935, upload-time = "2026-06-19T16:18:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/15/58/06ea038a30f55ad8a748d187d74aa83d2464979b058eaa6925a68455e6a9/pyobjc_framework_spritekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:a72410b7e9e4e1363f69dbcf1f2a0055275c7a3d205f707d5d29fa2406f39211", size = 18637, upload-time = "2026-06-19T16:18:13.439Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/cd/83f8a7508a43915ee5e88841b98deae8b5d1e3b0ce3a7596d3636a03a6da/pyobjc_framework_spritekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:79310eb2221dadcb5e0e8dae31f28f4d8f78cef73cebd7403220b82702ccb781", size = 18914, upload-time = "2026-06-19T16:18:14.251Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/06/d2c35beb5aec1b97ee13d72adceb6dfecfbdb1a4c836f89e9dd9e00c6e1c/pyobjc_framework_spritekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:3dc6f3f7db1b971175416481bf9b20d0f39be0a6266c04ed3a999e4755453256", size = 18649, upload-time = "2026-06-19T16:18:15.098Z" },
+    { url = "https://files.pythonhosted.org/packages/61/36/0ca18d7a78ceec1c2d0f2e7f1d993511fc7d138d676c5b9ffd12e6278bb5/pyobjc_framework_spritekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:22d2e8218bd59e05d37c2e0faa0f67711a3a1f0f78e3a1f31680c0587d2cb622", size = 18925, upload-time = "2026-06-19T16:18:16Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-storekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/2e/d299e11aefcc70414281e5f82e2297a314c108c5bf81091149f1c3f6411a/pyobjc_framework_storekit-12.2.1.tar.gz", hash = "sha256:5d3b306f08810c485a4bd184bc6e45cc92eaf4cb6d4b88bf701bcb854ab66f59", size = 40971, upload-time = "2026-06-19T16:21:50.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/ae/22edaf607a167973a5a857ef1c1a1c0b97f232d975953bc2ad6e05bce759/pyobjc_framework_storekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b90d2187290f6bb4b943a313b7c2adfd4865c11c8173781e6d48c01154b6d9d1", size = 12893, upload-time = "2026-06-19T16:18:18.041Z" },
+    { url = "https://files.pythonhosted.org/packages/09/09/9cb870b865d1adb49a910df20b2347ceecd07d906e58b14a5c807bf67e30/pyobjc_framework_storekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4394366c2d4442c41faadaa030202f4b8a6272b8ec25828a04504f5b40179b6e", size = 12903, upload-time = "2026-06-19T16:18:18.964Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7a/931bc925612fd74d09679ec976c45bdb2e41492e63d287594e11e6b1d5ac/pyobjc_framework_storekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3dab34b774ae217dfff0bc636925cd39c072300aed322e107936f15b9c2184ca", size = 12919, upload-time = "2026-06-19T16:18:19.987Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0b/eee8956c1d94824357ac92674ce9e4c96285612a22d290da00aad647291c/pyobjc_framework_storekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:11a40b897ef4d042079daf2fc4d05fe910d6fc737fdf15d3873875721fcea69a", size = 13117, upload-time = "2026-06-19T16:18:20.999Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/2e/5e2badd9e8b75b735dbc5cd37863410a1abe2bdb704b653bd2283a13b7ba/pyobjc_framework_storekit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0d398dd266a050944b7f3b3762820377edd7f4043829ea1be932a3b30896e72e", size = 12908, upload-time = "2026-06-19T16:18:21.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f0/af9c8e9a395a69015b0aabbd04853b438692c3a195d136c6f9ffe293a8b9/pyobjc_framework_storekit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8b4851593b80482e74dfd1c189b5140a79659069fae54aa3c505aaa859114e33", size = 13099, upload-time = "2026-06-19T16:18:22.753Z" },
+    { url = "https://files.pythonhosted.org/packages/59/09/eec2af1f269f73d54735b05069ce60cbe4e59db14b49e98d7afa3831b3c0/pyobjc_framework_storekit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0a958caa5905c3e2de270b09a75cb012a22499943df494cc899fb36b5541a28b", size = 12901, upload-time = "2026-06-19T16:18:23.981Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/01/3b2384b06ab47750c8f4ffb93137e265ef72fd1dcbb3035d806bc2f1e1f7/pyobjc_framework_storekit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ff6b0cd7ed194b248f1d4db50073b85fb6c67574183ae31c9261d94218c8881b", size = 13102, upload-time = "2026-06-19T16:18:24.762Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-symbols"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/1f/6575bd54a71ccae067b56cbe9277b65d095c9a9880c9e059d8d2e845a8ae/pyobjc_framework_symbols-12.2.1.tar.gz", hash = "sha256:c15d32ae7c94e0e95fd83bc2099437a70671b79d0f438a1b0cd1f3eb2cc6f365", size = 14778, upload-time = "2026-06-19T16:21:51.277Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/ae/163c7af387d5f65cbd55a5814596b1f4cb5c26b28e2e9ad6c2f331cc920b/pyobjc_framework_symbols-12.2.1-py2.py3-none-any.whl", hash = "sha256:95199cb08207680ee36bcfdc4cab5d4c5eaa0ae81e01b1a752066effa6c9b039", size = 3548, upload-time = "2026-06-19T16:18:25.705Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-syncservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coredata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/8d/ad9492c9f0a305e4a1e30968407385cd4bc61051a1a2f9c40677c964fff9/pyobjc_framework_syncservices-12.2.1.tar.gz", hash = "sha256:c351286f14d257e20f8305665825fd73f108c8f0d787e4643818dee5debb3511", size = 34867, upload-time = "2026-06-19T16:21:52.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/84/459e2c058d5d069b825afc722143afed6bc29347110abbc1f19b528835ce/pyobjc_framework_syncservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c4e2f5e4d2c72c6f4247bd8497a450a09652f84f6990a3ef089345f9a2475134", size = 13408, upload-time = "2026-06-19T16:18:28.336Z" },
+    { url = "https://files.pythonhosted.org/packages/37/43/504b6ef68ed22a3546aa42339f7e6c3d6953c856cbe28158ce231611eba3/pyobjc_framework_syncservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4cdce34f17d978f349e22dd6604a46bc01c25cd23142b856c393ffd28d6e687a", size = 13442, upload-time = "2026-06-19T16:18:29.174Z" },
+    { url = "https://files.pythonhosted.org/packages/da/de/feb58f62fb4a5a2970cb8660a48e4fd8f9480771c66a0c82ec3f87d25418/pyobjc_framework_syncservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4a569b68068163df043146b999b606e431b6cb4de4ccd24861031321fa442eda", size = 13455, upload-time = "2026-06-19T16:18:29.976Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/af/fd67ce6c70f9329261dff246322f08000fad6f96f940e8f0a3859c85d7ea/pyobjc_framework_syncservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8ade4390f80e4b8d9f94610a3310d1c4cadc195e7db09a9702bec39bd8a0aa8b", size = 13626, upload-time = "2026-06-19T16:18:31.254Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7d/78bced3548a0243c4cd0eeb7b4732972b1ee35d9750a1cb47a8e1aed9543/pyobjc_framework_syncservices-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:5aa55b01b440d9c2d3ac55c676b5a8e512d1adab43aec1012c3d0756f415de07", size = 13426, upload-time = "2026-06-19T16:18:32.078Z" },
+    { url = "https://files.pythonhosted.org/packages/12/74/65cbe27a99ca7cc8c4b6e30de51a040162a25d2d7ab6f5e3b17c12bdf2a8/pyobjc_framework_syncservices-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:dc0a3bfc317930edde03f76fd776d9aba548a911bd870b8a0b272091d2d3e852", size = 13613, upload-time = "2026-06-19T16:18:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/09/b936f2a9504161a570dd63231c4ebb4a18e822830eaf767abaddc2e3f1b3/pyobjc_framework_syncservices-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:5bc5b8981b29e45af0ec68040dc6313678217e83b556c6c7fd1b26e68e02f2d3", size = 13429, upload-time = "2026-06-19T16:18:33.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2a/26c5e0b8256917b0f19e7bd056df0bec241288ae286266331c21d85c40ca/pyobjc_framework_syncservices-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:b10b47d7242b8db20230da090b72b6fe688d513b0ec0d47bb3abff1bcf6b61b5", size = 13611, upload-time = "2026-06-19T16:18:34.941Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-systemconfiguration"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/6f/805ee24f58c13eb593e458ec1f79d94d3415edace02eec7c614ef3518f69/pyobjc_framework_systemconfiguration-12.2.1.tar.gz", hash = "sha256:877a90eafe3df72625e50d61fc9c6dbd40e8cdabab7c4101992090107bb71ddb", size = 63314, upload-time = "2026-06-19T16:21:53.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/95/50cab59ebfe08dd2c4856da113bb5f74102d915b699c2e3988af3550ccfc/pyobjc_framework_systemconfiguration-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:df9a278948483d40d56a780a99e692b9bdeb2be6279f8f59c96fbd31f620eb72", size = 21674, upload-time = "2026-06-19T16:18:36.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/f153e2db0cc3724b6cd3c1e939149fb93a6d7b4b9c0ab75a8d7ecdadb02f/pyobjc_framework_systemconfiguration-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9671060ab587eaf485eb8e1d6b328d664ba4a210c4ebffbf7dd2705d741bf90a", size = 21570, upload-time = "2026-06-19T16:18:37.853Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bb/ecff9943e5bd24b78319f683e9219209db502f46a3dff24d1e50bcf9d74c/pyobjc_framework_systemconfiguration-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:06e93a97364681543592bff38f801e2942eb272d68101ccbf3278a8fa043c645", size = 21565, upload-time = "2026-06-19T16:18:38.829Z" },
+    { url = "https://files.pythonhosted.org/packages/71/dc/ecc0b5a79d54507be2a3bb8a5088471bbd2a5bd8d2f89dd07538f3bf2551/pyobjc_framework_systemconfiguration-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e3aa4706f81d8334c717d44567314ebbdf03e62259ede99a89f4703789c212a2", size = 21979, upload-time = "2026-06-19T16:18:39.662Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f7/8e476085716dce017c92c1b24f66a49d09d5bb86d45a82942df6296086d1/pyobjc_framework_systemconfiguration-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c1327154369fd07dd0b9f02a4fd65068c531ffa99f8e0efbab51f03446750f33", size = 21587, upload-time = "2026-06-19T16:18:40.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ee/404d50f15729d0cdc06f89763b089ccf86ef2103776332ac5313a6a31067/pyobjc_framework_systemconfiguration-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2573755bdc6480470d2cf2cb24c529371bcc3658953ba0efa87e0a6af5b68144", size = 21983, upload-time = "2026-06-19T16:18:41.497Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/43/40c9c0d44007c8185d992da1b1d39359acdf701d1c41f14e274bb676c7b9/pyobjc_framework_systemconfiguration-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:150e1b5f35c4badf34b98c56aacc128f631d5084857c86ccccfb4d78e35a7257", size = 21601, upload-time = "2026-06-19T16:18:42.357Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ff/a637bebb60880c96dcad2c888e66d4eb2f6d2609ceea3cfd1fad606384d4/pyobjc_framework_systemconfiguration-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:a1ac9972a24e8900bd09313afe3550579a3e7ef643766f38da2f965e0d9c7e1f", size = 21995, upload-time = "2026-06-19T16:18:43.339Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-systemextensions"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/1b/6edbfef0f03ff67bc22ba03ac7027aee804ea5b16512dd9547dab5786c81/pyobjc_framework_systemextensions-12.2.1.tar.gz", hash = "sha256:4f9f6d729544acfab49fe02a4b38712112c51f07790f8d4bf7ac3bb18c334839", size = 21667, upload-time = "2026-06-19T16:21:53.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/30/d50fc19821ae25d43fb0bde681891fa4715d41783f96156dd7a1f77a3ca7/pyobjc_framework_systemextensions-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:21d5993eee958be7f445ec2f0616c4213773cbcd9213346f4ad367037e5acba0", size = 9208, upload-time = "2026-06-19T16:18:45.178Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/a70c451b3ae4cf8387b0f0d709754e8f87db7057f2e0bb5ab0d73f96cc98/pyobjc_framework_systemextensions-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b871a52125eff3c6ea10b769920d64fddcbc26a58bb3759545f914cf0c5cc9fa", size = 9221, upload-time = "2026-06-19T16:18:45.995Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/20ec0f1239d58a0f8ccaebfc545f27c26904faab81f4e6e7d07efeba1f71/pyobjc_framework_systemextensions-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ded8228991aedcc2b3f9d8c7a0af5f9e9cd9125af562d68817e6ce0bf8a2a713", size = 9239, upload-time = "2026-06-19T16:18:47.155Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/94/c6f40110f2da5bbea11f41ed906888aa726bc22b465b39027b1ea5d4c516/pyobjc_framework_systemextensions-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ae954da6267be3d7bafd53ee8357c8b5d3c13dd56359a0d862b69f5cb7eea260", size = 9395, upload-time = "2026-06-19T16:18:48.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/41/0c7ec750b86f92e4100bfabf9adb121516b0c869fb3da39b4d6214e388b4/pyobjc_framework_systemextensions-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9231d0d14502d51e18a2ba89a4d7f2e310489b0f60e2b951887e8852880563ca", size = 9306, upload-time = "2026-06-19T16:18:49.309Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1b/bafbd1f9f53b31f8dcf1f4775206de0cd07fd66d1aecd9b39ba9f9e96507/pyobjc_framework_systemextensions-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a38e9ef6f5fa5f4dbc4d1e6bae8d169f3f0301a52e14de45ad3631033daa4436", size = 9464, upload-time = "2026-06-19T16:18:50.151Z" },
+    { url = "https://files.pythonhosted.org/packages/04/24/a36d6951585b12ec57c3d98c103046ebb34bfc5a1c48df0ea2d7b54c3401/pyobjc_framework_systemextensions-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:dfb2884c0fe97893c4b226dd7d95bdec43f7f8a574347a1e80280bbf87230736", size = 9302, upload-time = "2026-06-19T16:18:50.947Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/6c/da629b65b470c5eec528e1e8ec703d8654701bd03078bf1e15df508b1950/pyobjc_framework_systemextensions-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1412d2c62f9df0f52160f7edafcdd608259b6c70925cdb520f45f16a46d2c685", size = 9465, upload-time = "2026-06-19T16:18:52.08Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-threadnetwork"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ae/a2f44eade30d2231938acb81ef049f4172afd6e9acbdff55eca036e75038/pyobjc_framework_threadnetwork-12.2.1.tar.gz", hash = "sha256:98397cf45354750c4b5a1237f6961c616d12f3ad0a570b3808a03e5d3373f64a", size = 13341, upload-time = "2026-06-19T16:21:54.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/cd/822620f1c4f00e24fced4a267113a77d7fafe394d0b516b8c94ff01f62b0/pyobjc_framework_threadnetwork-12.2.1-py2.py3-none-any.whl", hash = "sha256:75afa29eb2884cb9c5ddf5bbc81fed7f45f168422ae897c1a791374152c9ffd0", size = 3827, upload-time = "2026-06-19T16:18:53.181Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-uniformtypeidentifiers"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/108fa1e5a3dd8aff626f98fb97de370323b290404b04ffa2ef9420665ed3/pyobjc_framework_uniformtypeidentifiers-12.2.1.tar.gz", hash = "sha256:1fb89d13aa3c2df8e6d6536f6df3493fe5a6caefd2a5adebf17c5af3b29ed4a2", size = 20679, upload-time = "2026-06-19T16:21:55.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/44/18a7b3c3b4f9f6784fddf64ed5a2c148577d0300705a50e8ab81da8fc71d/pyobjc_framework_uniformtypeidentifiers-12.2.1-py2.py3-none-any.whl", hash = "sha256:ea08413ad895a7dfea13670e26548bcf5b00154084cdfb5d8f96603320e77cf3", size = 5042, upload-time = "2026-06-19T16:18:54.085Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-usernotifications"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/77/bdd49a1fe4d89ce86078e94121cf6e9c7e2f733215556194da04c512075e/pyobjc_framework_usernotifications-12.2.1.tar.gz", hash = "sha256:64379ab6b603949ea20b7852343cbcff7403443b4876ec8ac0c03bd0f11b1b22", size = 33955, upload-time = "2026-06-19T16:21:56.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/a8/4de5e87308d3803b4c49acabf885d408ee490d2d019ad224c0f72da2235f/pyobjc_framework_usernotifications-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:74e7e7af3bd5842502ee553f4d0ec566f698195bb89ae925c91441c86a0aa5da", size = 10195, upload-time = "2026-06-19T16:18:56.111Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2d/c40189560f8db4ab9f29a9c79eb7b2d89544d80a27252de5112ebcabdd4b/pyobjc_framework_usernotifications-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:12fab51085e4796e04783e457d9355b805afbd1cb13bf9d207e5fb7e1a32fb36", size = 10211, upload-time = "2026-06-19T16:18:56.988Z" },
+    { url = "https://files.pythonhosted.org/packages/21/71/cff5abc272742148f086cf00b5625e6a7f23171dd7b23d075f16a26e47c9/pyobjc_framework_usernotifications-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:273ef82c7ddc1701d56b586cde2615360618c1b2d17fb5c24bac77a5f02b6092", size = 10221, upload-time = "2026-06-19T16:18:57.775Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/75b4c4c15dd4f4f3c190424244ca35976e3a29c51740b7648f3fa78eb73a/pyobjc_framework_usernotifications-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e872d65dc71bc297401819106b5e5c4b758aa38247d74284bce20e63a2bdbfa1", size = 10379, upload-time = "2026-06-19T16:18:58.507Z" },
+    { url = "https://files.pythonhosted.org/packages/36/00/7a7c79a3700bcc24c9cabfac984ae38ddcfef72e6564aeaf4c3237009279/pyobjc_framework_usernotifications-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b43a46b4a95bdbf0d2acf1ec0d709b376c4149c618693a05745485c741ad4f28", size = 10283, upload-time = "2026-06-19T16:18:59.418Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/81/dda0b17f8761bf9aec3e1eb26aedb5590a51946ff4e8ef62e12870c639fd/pyobjc_framework_usernotifications-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4050919639556e63854e9965d942f928745ac346b52b0cb7acd3823b8a9af153", size = 10444, upload-time = "2026-06-19T16:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/bd/4b6d4d7aea2f1b99f73548f01f964769e04574e0bd823afad003736290e1/pyobjc_framework_usernotifications-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:0811da6cf3e4b5dce91ad61888204b08281b86c889c4241309f55bcf996bce03", size = 10280, upload-time = "2026-06-19T16:19:01.116Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8c/fcaadbea1daa56e73aef844f89e2534b51b04e61881e2b6cef0727e0f72f/pyobjc_framework_usernotifications-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:fc70d0f149716b8488934921a28e96716d2db7eeac4bcb1043b970c52d551613", size = 10445, upload-time = "2026-06-19T16:19:01.904Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-usernotificationsui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-usernotifications" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/9a/566813aed69566c68045fc080b2238f62df131826d16da42529e89d56434/pyobjc_framework_usernotificationsui-12.2.1.tar.gz", hash = "sha256:ea6aecea828e088416aa6d14055c023cac6aa03ea0cdded8baba679ce5414cc8", size = 13457, upload-time = "2026-06-19T16:21:57.294Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/4d/ae257ba381d779ff760eea94fc12df5aded3bbf9da4304f66f70962ad68c/pyobjc_framework_usernotificationsui-12.2.1-py2.py3-none-any.whl", hash = "sha256:25464587228e128758a1ea9d8b0abdb872d2a957d1c554d791796a39ddc0e4ce", size = 3953, upload-time = "2026-06-19T16:19:02.794Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-videosubscriberaccount"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/4a/b3485f9e123b05a44852f07ca9387d8ad719a3ecbe0a10e2d2f726a460ff/pyobjc_framework_videosubscriberaccount-12.2.1.tar.gz", hash = "sha256:7af53b410d3943be09d8601bd8d50fd0e193e4e5577fdaa2f801d7f9dbc0454d", size = 21346, upload-time = "2026-06-19T16:21:58.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/78/4dc23b84c668c10dfde26c861c697b4bd682d1d137422a0546e742c08455/pyobjc_framework_videosubscriberaccount-12.2.1-py2.py3-none-any.whl", hash = "sha256:ac43567833a4aa21fec81d39449d080b2cd58d6b02de76b57004067bdf37ba76", size = 4890, upload-time = "2026-06-19T16:19:03.85Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-videotoolbox"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/82/307369b27b00b38cf6b6e021fcdce0ae6f1a91f24fed9b090addbe90f1e2/pyobjc_framework_videotoolbox-12.2.1.tar.gz", hash = "sha256:83582abc25e55ed04f0267fa69923839d779a11da3d34ee8c93ad1a66439e48d", size = 64995, upload-time = "2026-06-19T16:21:59.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/0c/8693571c03dacaf86a21c79035dbc36e0fd39422f55251b8d1ed5c5dc0b2/pyobjc_framework_videotoolbox-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eed49d96127b0a52afe88a78ee3ea28cbc39c8d274cab1c921cc64a46201b0d6", size = 18877, upload-time = "2026-06-19T16:19:05.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/64/804ef9bda687dd3ead9ecd9e2fe29842a5acaee95bfa5f5d6932716090e9/pyobjc_framework_videotoolbox-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:67e03405bf7ea4790688c3937c5838dd8e1d25aa95923a7bb71ba3c49031d1af", size = 19004, upload-time = "2026-06-19T16:19:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/eb/771c0564a82e4e9ff8a4369100d6a3720824ac65a8e899c70da970e89ed4/pyobjc_framework_videotoolbox-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:efead1dc80cfd7612b952e831bb1e4b3ce9b13e6e4848ee82c28fcd5eaf718d3", size = 19024, upload-time = "2026-06-19T16:19:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e7/0725ee9ad4576c432fcc38f90c78b0f377034aa71460420d4dde649a1d00/pyobjc_framework_videotoolbox-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:45bb85a114280763e7b4b5f9f726be1b0ed97041ef3816e77fee2268211d6732", size = 19231, upload-time = "2026-06-19T16:19:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/68/54/65e0076b81322d53b1235fab0e180be212a906cbe1f0e94c4875dfa052f5/pyobjc_framework_videotoolbox-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0fb2e7be0568af5864077be2856a88121667f839e96304907b05a4b6ecd770e0", size = 19017, upload-time = "2026-06-19T16:19:09.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/3685cc3c4ec52086a5a1e26cf3574e2c7f84214a86cdd1e1f19c21ef616f/pyobjc_framework_videotoolbox-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:eb0d58dc6ce118c5e8610fc76112a769a02fb6ed201e4f89c655ca1ac75218be", size = 19215, upload-time = "2026-06-19T16:19:10.088Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b6/b956d04ddd26a8b07d3df0a49f0352cc773203a14e3fdcd98edf2f42d024/pyobjc_framework_videotoolbox-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:37d70510fb35f85a3ef4e37047e0ed6008e78bc83728ece763efb87d2919ca75", size = 19025, upload-time = "2026-06-19T16:19:10.945Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/80/ffb0ba5ad6911fe66e7faa8901cbbb580facc9f41ed05cbb41751ebe2512/pyobjc_framework_videotoolbox-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:0339694a3caaa3a6415a5c845b812caedaecba8be9b322c17777d9e4258ff203", size = 19215, upload-time = "2026-06-19T16:19:11.995Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-virtualization"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/49/5c306fac7b85c4f875b01f38266b75b9b8ba80a9747bfcc692c9b83adffb/pyobjc_framework_virtualization-12.2.1.tar.gz", hash = "sha256:dd752180219ddc54112876576debca9f3316e91ce75afce622981eeb8c9a0f4a", size = 49190, upload-time = "2026-06-19T16:22:00.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/4a/eb0b108eb7720f647a26bbf6a477cec09f9138df93e470473fb35f96df0a/pyobjc_framework_virtualization-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0137793bee5c628b6f9e44a773e49e3f68f758ef5b08ce407a9910b907ee6092", size = 13592, upload-time = "2026-06-19T16:19:14.052Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0a/d5e4670a5b12fa3150b25b7f7a7694a72d8895527d33c0e33d63753a7086/pyobjc_framework_virtualization-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6c90011e2f90dd5593996cb80f9c4739bd4a12db7303086678217a08909ee045", size = 13626, upload-time = "2026-06-19T16:19:15.082Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d3/fb9b5f4d457715d165293cf7112d7405128ab461c957c7dbe19d4dba5ca3/pyobjc_framework_virtualization-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee6423823b4b851d76567e44c649493eff6cda7ada94a86942a4c706f3e22f36", size = 13642, upload-time = "2026-06-19T16:19:16.051Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8c/146a46d88eaa8071f36c28c759790ba853b5d4630d53f22d8d74a871f13b/pyobjc_framework_virtualization-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:862c7d9c8ddb47eb086bb55271459e6107be904c526bdd3d520787a89d4e6c72", size = 13841, upload-time = "2026-06-19T16:19:16.928Z" },
+    { url = "https://files.pythonhosted.org/packages/81/84/03fd75be82d47a27ca16bf8c5b467a78322a5e3692b5d76bd67b14d27a3e/pyobjc_framework_virtualization-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:047ae558051db4682f42f8d18f3391aa454ae5b64ef676c4e7580323aa457a87", size = 13628, upload-time = "2026-06-19T16:19:17.814Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5e/587ebffbd4f9781b88fc18607f10ba17510df40fc79cb6660a4a9a6c64cb/pyobjc_framework_virtualization-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:503cbd9b7d995500a6dcaa0c3d131c41d3b694a9789d396465205fdf0090a130", size = 13836, upload-time = "2026-06-19T16:19:18.67Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/07/455cf0cdae517ab0b879621b5c48ee81228d9305fa995ce982be5f4f0c55/pyobjc_framework_virtualization-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:363f43c0a96c41d4cb1430c9faa5cc7c8b5cdaa2c66bc0be93e904c8611a5feb", size = 13621, upload-time = "2026-06-19T16:19:19.487Z" },
+    { url = "https://files.pythonhosted.org/packages/47/96/53ca0653a397196b2ba4969d6f0820102336de4d420b3311050b4630eff8/pyobjc_framework_virtualization-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ab87f688824575e0e09dcb0672f59ca76d468c55c229e34a356d4ee5ccc757b9", size = 13832, upload-time = "2026-06-19T16:19:20.337Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-vision"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreml" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/7a/1fdffff1b6bf124b260a2169869f4b71a08b9f6603698f7dec990d5ae5f3/pyobjc_framework_vision-12.2.1.tar.gz", hash = "sha256:debfd59dd7d962a6053bf733370148c11a9ec44091b517a0966f48d81c305879", size = 72683, upload-time = "2026-06-19T16:22:01.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/dc/a4043619a8c1bae2ef0463ebf88b3d2d5973ad5809dcc5d2d5fc93f34151/pyobjc_framework_vision-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:86f221d7ced483e7292194293b791a255e0bd1e4011048533501679e378d40fd", size = 21794, upload-time = "2026-06-19T16:19:22.356Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/1b/ee3aa7d1517d2d161cd9c2d00b9fc19206d2472b4bb35e98835ec9992d02/pyobjc_framework_vision-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fa2e56d891eab12a0ddac2373c69957c108f70dea56f5a9a6081a3c2f905c98b", size = 16947, upload-time = "2026-06-19T16:19:23.209Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/1bc00a6b6031b7d6985a0547d2b41ed4ea029c3ffbfe31c8040bb14f6674/pyobjc_framework_vision-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a041188213ae84153d5fe74cd69468827c150cb7157e2649e40a2a3cedb8f55d", size = 16963, upload-time = "2026-06-19T16:19:23.99Z" },
+    { url = "https://files.pythonhosted.org/packages/59/af/e6618858bd8f9be6c58ea7238b7ec224d1a31df506dd912c41672fe4f369/pyobjc_framework_vision-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e288cb41349d6e84cfac0822a0c1fb476bf5fa094913b19e8c2899e90a1a9e8f", size = 17105, upload-time = "2026-06-19T16:19:24.817Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/76/67d7098ab8e3d55b24425feccf452620f234d558400d9e5eb7ca56c60a9d/pyobjc_framework_vision-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:da4f6811c23bdfa701ed727d6e46a83729606476cee435c2461f0f25579b8080", size = 16939, upload-time = "2026-06-19T16:19:25.627Z" },
+    { url = "https://files.pythonhosted.org/packages/97/99/9b46821533d1b138e69a230cc17ee6a7be24bcb6093daf6ab2096fdc21d5/pyobjc_framework_vision-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a319b6e809ac03c41fbbcb1b8e449c8bc9b6e2b0e06c3c67cbe4ce8e040a1f78", size = 17097, upload-time = "2026-06-19T16:19:26.538Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6d/74e275165801d0309f9915b0def9b73f546b1ab378892f86e5bb26a2f2d3/pyobjc_framework_vision-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:2dd7ce3563afbbcbc10d9bb5e777b3d0cd77d4d5a9f7b0c32d0f65eeb5d34f0f", size = 16927, upload-time = "2026-06-19T16:19:27.351Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/e2b0286125ddbe475e74de668b470b8d9bec7a26cd95de70178f8b382ca4/pyobjc_framework_vision-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:5aafb8fd87b5580b98a9f4a6de18013fd000f78a5f0930b2160fa82775de84fd", size = 17097, upload-time = "2026-06-19T16:19:28.232Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-webkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/d2/b230c594f70ecb970b4cef67bae2648d1bfa5b381e9b7e3710bf24ec8887/pyobjc_framework_webkit-12.2.1.tar.gz", hash = "sha256:a56acae55b50d549b20dff2921ad1099add8fbc377d0de09ddc2ba50957f7def", size = 332374, upload-time = "2026-06-19T16:22:01.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/d3/2ab99d3975dd4624dd943e5a7c8d37e40258d3c9fcf4f26baf09a24e6c9b/pyobjc_framework_webkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:af5c4ccdf03845adac082823a3b4341b5b2fe62d2d664550afa705b5286a06fc", size = 50264, upload-time = "2026-06-19T16:19:30.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/47/7a2099eb2e062c6230a9440f1795cf34056ca5e16ef25c8aad7c059b8734/pyobjc_framework_webkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7e04dcc08cdc59380113ea1232af75a0a04c2426418ebe967b4c0045c973f776", size = 50372, upload-time = "2026-06-19T16:19:31.581Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a4/202ec288808011d3f459d000d593e88b1118f2d1d5a4dfaaf5232f2c2ac2/pyobjc_framework_webkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:23bee8bf7077f91da4e3ae54a00c7f5e4414319e15f98be8584dbd67c4043fae", size = 50387, upload-time = "2026-06-19T16:19:32.522Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a4/f796e94b43a66704b6ae17c747c7b97fd4b79348f1cfa9bef7b008aaa718/pyobjc_framework_webkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:00ffb254f97e9ffdd0a82c1faa61a07f6072ba900fa8aba70c83c21198b52e4e", size = 50853, upload-time = "2026-06-19T16:19:33.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/d24716fef19ccc3d880e99029458803f0174c05df310d991eb97ea3a0799/pyobjc_framework_webkit-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:67030258c3cd66e8495ccfccef3d2d58010ff0209284c5115e5afdb0e9fd6de1", size = 50499, upload-time = "2026-06-19T16:19:34.45Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/6c/817119a52efcc229a30ceff56a0641005a431806a1f555e0571626ba313a/pyobjc_framework_webkit-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5d91527c9950c79269dd0d70f2bb8668c298dd06930637c1c063ce5f274a87e5", size = 50967, upload-time = "2026-06-19T16:19:35.474Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/59/5fac0754d53b2a72aed6f424dfc72e5fa245f83cb57c2e00d02e45390fca/pyobjc_framework_webkit-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:657825081484c9920c50b76b469b9583f116225b0449c9d95c46cbc8c640adc8", size = 50498, upload-time = "2026-06-19T16:19:36.397Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0c/e997e33d99d4ad91da2cf70f0e51ac39b03c58ba210548e9e944bbb421be/pyobjc_framework_webkit-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:f46adcc6227873f2b14d74b2e789c937f227722274ab59b9fa3c04c6ecb46dd5", size = 50958, upload-time = "2026-06-19T16:19:37.424Z" },
+]
+
+[[package]]
+name = "pypiwin32"
+version = "223"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/e8/4f38eb30c4dae36634a53c5b2cd73b517ea3607e10d00f61f2494449cec0/pypiwin32-223.tar.gz", hash = "sha256:71be40c1fbd28594214ecaecb58e7aa8b708eabfa0125c8a109ebd51edbd776a", size = 622, upload-time = "2018-02-26T00:43:23.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/1b/2f292bbd742e369a100c91faa0483172cd91a1a422a6692055ac920946c5/pypiwin32-223-py3-none-any.whl", hash = "sha256:67adf399debc1d5d14dffc1ab5acacb800da569754fafdc576b2a039485aa775", size = 1674, upload-time = "2018-02-26T00:43:23.108Z" },
+]
+
+[[package]]
+name = "pyside6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-addons" },
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/a6/27ba5947ed48918f7b74b7c43a1e280aac069e36f25adeb4c9adfac835c4/pyside6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:537682c3b7530817203e667c1f5a2f00486b37bf52c52eeab438544c7a0917f6", size = 571921, upload-time = "2026-05-13T09:47:36.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/de/af89d71410c83b10654d86ff9aff2a4f87c30163658f1cc145242e222526/pyside6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b1fc521ba2bb5109425ab8add06bddbdd524abcad06cfa012cc39a22a189feb2", size = 572102, upload-time = "2026-05-13T09:47:38.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0e/d583bd3f7bf5046a4497b36f3902cfb64aa29554489a5a25c18e6b4ac0ac/pyside6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:75f0005c3eb95c07cfb65522ec50d0815ac007a96482c21dc3cb4b4c04895d84", size = 572098, upload-time = "2026-05-13T09:47:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f2/d9d8ce1373dabb37e5919f63cd18446556079631d3f2eea3ada03c29f6b8/pyside6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0968877ab1fb4ef3587a284da6fe05e8647ada56a6a3750b6395188e01f4aba6", size = 578377, upload-time = "2026-05-13T09:47:40.76Z" },
+    { url = "https://files.pythonhosted.org/packages/96/02/a6057d8bd2bdb1940820fff2d627fdf4013148c9c57adf69fa40d3452ac3/pyside6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:acee467cb5f256cc47ebb9d815a054c1d8416da380c191b247a76d164aa3f805", size = 561765, upload-time = "2026-05-13T09:47:41.9Z" },
+]
+
+[[package]]
+name = "pyside6-addons"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/6b/8bc94aff48b63f788f2d84e5467c12362d68906ba742c0942f46cb04c879/pyside6_addons-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:54733c77f789bef5f03c6aff4ad3bec8b2eff021f0cfcbc53d5e6c250ded24f9", size = 331714589, upload-time = "2026-05-13T09:39:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/62/fb1428a523b2a4541e232aab50d9e789e6b4526f37fd9593452a7ea5b6b3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8e6c65fbd73a512d6f72cda8d8277444a85a34dc99dd1dae9c21d35b8671bb1f", size = 175063224, upload-time = "2026-05-13T09:39:34.185Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9b/2ccd52f66db55c06de65d0501170a1935d04d64d0a230c0d892284a02ce3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:bf1c6c4e954e5eba3d2a7c661ad4b9689e8f09c7f4a16bdf29713371d11af993", size = 170553429, upload-time = "2026-05-13T09:39:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bd/8adc4d350b3b363f3dfc8fccdcf5bfed25f7e36c2fff30c64e106f4f1572/pyside6_addons-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:0d13c4dfd671b050a48e4f8d8ddc724b7248f9c0437e7fc47fdf316278572923", size = 168816308, upload-time = "2026-05-13T09:40:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b7/9a840d97f0f0f04e372a87e205dd30ee285b4e3b021b188459a917c9dc76/pyside6_addons-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:3494f480dee92f415be2f2d989c0b3f4755ac332b28045cbf4ba0f5c5a22ba37", size = 35759347, upload-time = "2026-05-13T09:40:21.199Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/da/10d9197e7370eb4fed8df5fc547b7548dec88e5c5949e2d450db4ae96feb/pyside6_essentials-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:228de53c2bc26b07e5021fbe3614fc44ca08e4dab9999af08c2b389d2c239957", size = 110352945, upload-time = "2026-05-13T09:43:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/49/0e1237c4400bec7e335d2c4eeb49bc40d9fd88a9ac44ca9083ce1abdc308/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:e3ef7027b41e4e55fadb56e3b3257dc8ee92154b639fe67fc4c8e05e9d976c60", size = 79908535, upload-time = "2026-05-13T09:43:24.836Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/c5/da4c5f23c6540ac5211a1f60177c8dee84b1bf40f2719479587ab8c60731/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a039b6da68a3a4b9d243217b2b98d475eed3f617159ef6be925badab53c11b0d", size = 78960051, upload-time = "2026-05-13T09:43:35.423Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/b663ecc96ca57b5c91b83b6615d6b174380b0faf30338125c26e053d6aa7/pyside6_essentials-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:63311bd48e32c584599ab04b9ef7c324082374cd2c9fa533f978fb893bb47e40", size = 77549267, upload-time = "2026-05-13T09:43:44.92Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/eb6723faf5cb7fa581145da1c15f40d641b96e080f0491af2f1859fdeedb/pyside6_essentials-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:11253ea52aabecefe9febddbbe78b43a824129e3af1cec98431028fba7fa954f", size = 57964512, upload-time = "2026-05-13T09:43:52.968Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pyttsx3"
+version = "2.99"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comtypes", marker = "sys_platform == 'win32'" },
+    { name = "pyobjc", marker = "sys_platform == 'darwin'" },
+    { name = "pypiwin32", marker = "sys_platform == 'win32'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/4e/a37786f666f4f084fc45e026ca1e63f7b49ac0d90b53fa35ae62b73c96a8/pyttsx3-2.99.tar.gz", hash = "sha256:a18a5601530a570c43491b4112887fc34c47e118fc937287db8d21905da1f74e", size = 33968, upload-time = "2025-07-08T12:24:21.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/14/9fb5842581f0419b5eb85f8c26c1c0c0f4cf6b4d5be638ae3157316a2650/pyttsx3-2.99-py3-none-any.whl", hash = "sha256:ff3e4ff756c24d72b9f3f2f304e0edaafd0f58adb0e6f4b90d930440cda8b207", size = 32157, upload-time = "2025-07-08T12:24:20.299Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.11.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/f3/f2b63df0251e7cd3172ea28e32ede52739de9566bcefcd0178681538ac81/shiboken6-6.11.1-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:1a16867f103ef1c662a5f09dfed03273a9f81688b174555162c58e83650a3f02", size = 476874, upload-time = "2026-05-13T09:47:01.091Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9b/e0355d8897b5c150770f1d95718aad17d432fcc9c035c04f3f58427d4693/shiboken6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9a8bccfafc8805254cabcfa1edfaf55cd52889f4998c91ad0d9a4433fb1bcdbe", size = 272222, upload-time = "2026-05-13T09:47:02.653Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d5/dd4f1defed400be03340f2ede34b61f846776650b4e7ed9ebaf4c71979a2/shiboken6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:1bd2f4314414df2d122d9f646e03b731bc6d6b5f77a5f53f99a4fe4e97d84e6f", size = 270350, upload-time = "2026-05-13T09:47:04.02Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/3f6fb2ee65b534193fb4ef713dd619dc31dadff5d12c16979a7699ad58be/shiboken6-6.11.1-cp310-abi3-win_amd64.whl", hash = "sha256:c2c6863aa80ec18c0f82cea3417837b279cdc60024ac17123461dc9042577df7", size = 1223647, upload-time = "2026-05-13T09:47:05.924Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d1/f15ca0e1666faae02c945f48e745ea35f8fcd8243b176109b4e2c4251f47/shiboken6-6.11.1-cp310-abi3-win_arm64.whl", hash = "sha256:7c8d9af17db4495d4fa5b1c393f218311c4855546b9dfa6a0bd21bcd66b55e9d", size = 1784170, upload-time = "2026-05-13T09:47:07.617Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/fe/cba54dc58523434919b66f13a667e36e436deddd77ca519e96553617d4ec/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", size = 111187938, upload-time = "2026-07-08T16:05:17.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/59/1e3160e18e12aa3038390efab3ce02b36a9d4d6a527ecdd8520dca2e68d8/torch-2.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:092790c696a760c729fd5722835f50b9d81fd7c8f141571f3f3cf4081a8f664c", size = 427199369, upload-time = "2026-07-08T16:04:51.054Z" },
+    { url = "https://files.pythonhosted.org/packages/01/79/1f2d34ad7034ee1c7ffc1cf8bf0f8213af2a81df6ecdb3997ecec107c09d/torch-2.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:60fcdcb2f3876e21146cb4524ef06397d727ca9ad5f020818547e25075fe3cb7", size = 526574961, upload-time = "2026-07-08T16:04:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/0f2ce40f58aefbdb3392f9acce3c8171940943ae2d661f70558bfa73befb/torch-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0d8b11f16a48d60e2015d8213aa0390744cbebb98e58b62b3514dddc656e330", size = 122015870, upload-time = "2026-07-08T16:05:27.59Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f9/19d842d06a08559534fa1eaab6ca551b1bcf40f06620bddec1babaa2772d/triton-3.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a0e1cd4c4a76370ed74a8432a53cea28716827d19e40ffc732233e35ceb3f6", size = 184664887, upload-time = "2026-06-17T20:03:42.913Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5e/fce69606f7f240297f163e25539906732b199530d486ce67ae319877e821/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6744957e9fd610a29680ec2346057d0c86948ed3812468670719f391e94b44a5", size = 197701306, upload-time = "2026-06-17T19:53:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.51.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
+]


### PR DESCRIPTION
## Summary
Add ASCII heatmap visualization of gloss sample coverage.

## Changes
- New `data heatmap` CLI command
- Groups glosses by first letter with green/red indicators
- Lists missing glosses

Closes #223