### PR TITLE
Add WLASL manifest adapter

### DIFF
--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -12,6 +12,7 @@ from loru import __version__
 from loru.config import OUT_DIR, RUNS_DIR, SAMPLES_DIR
 from loru.data.loader import list_sample_files, sequence_summary
 from loru.data.stats import compute_sequence_stats, detect_outliers, print_stats_table, print_outliers_table, print_summary
+from loru.data.wlasl import load_wlasl_manifest, write_wlasl_manifest
 from loru.infer.pipeline import sign_to_voice
 from loru.infer.text import gloss_to_sentence, multi_gloss_to_sentence, sign_to_text
 from loru.models.vocab import DEFAULT_GLOSS
@@ -163,6 +164,38 @@ def data_coverage() -> None:
         table.add_row(g, "yes" if ok else "no")
     console.print(table)
     console.print(f"[dim]{have}/{len(DEFAULT_GLOSS)} glosses have samples[/dim]")
+
+
+@data_app.command("wlasl-manifest")
+def data_wlasl_manifest(
+    index: Path = typer.Option(
+        ...,
+        "--index",
+        "-i",
+        exists=True,
+        dir_okay=False,
+        help="WLASL-style index JSON file.",
+    ),
+    samples_dir: Path | None = typer.Option(
+        None,
+        "--samples-dir",
+        file_okay=False,
+        help="Directory of local Loru sample JSON files to match by normalized gloss.",
+    ),
+    out: Path | None = typer.Option(
+        None,
+        "--out",
+        "-o",
+        help="Optional output path for the converted manifest JSON.",
+    ),
+) -> None:
+    """Convert WLASL-style metadata into a Loru sequence manifest."""
+    if out:
+        manifest = write_wlasl_manifest(index, out, samples_dir=samples_dir)
+        console.print(f"[green]WLASL manifest[/green] {out} entries={len(manifest)}")
+        return
+
+    console.print_json(data=load_wlasl_manifest(index, samples_dir=samples_dir))
 
 
 @data_app.command("export-csv")

--- a/src/loru/data/wlasl.py
+++ b/src/loru/data/wlasl.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+SEQUENCE_PATH_KEYS = ("sequence_path", "loru_sequence", "sample_path")
+SOURCE_URL_KEYS = ("url", "source_url", "video_url")
+METADATA_KEYS = ("bbox", "fps", "signer_id", "source", "variation_id")
+
+
+def normalize_gloss(gloss: object) -> str:
+    """Normalize WLASL gloss text to the sample-file style used by Loru."""
+    value = str(gloss or "").strip().lower().replace("-", " ")
+    return "_".join(part for part in value.split() if part)
+
+
+def load_wlasl_manifest(index_path: Path, samples_dir: Path | None = None) -> list[dict[str, Any]]:
+    """Convert a WLASL-style index JSON file into Loru manifest entries.
+
+    The adapter reads local metadata only. It does not download source videos; if
+    a matching local Loru sample exists, the manifest points at that JSON file.
+    """
+    index_path = Path(index_path)
+    payload = json.loads(index_path.read_text(encoding="utf-8"))
+    manifests: list[dict[str, Any]] = []
+
+    for entry in _index_entries(payload):
+        original_gloss = _lookup(entry, (), ("gloss", "word"))
+        gloss = normalize_gloss(original_gloss)
+        if not gloss:
+            continue
+
+        instances = entry.get("instances") if isinstance(entry.get("instances"), list) else [entry]
+        for position, instance in enumerate(instances):
+            if not isinstance(instance, dict):
+                continue
+            sequence_path = _resolve_sequence_path(instance, index_path.parent, gloss, samples_dir)
+            manifests.append(
+                {
+                    "dataset": "wlasl",
+                    "gloss": gloss,
+                    "original_gloss": str(original_gloss or gloss),
+                    "video_id": str(_lookup(instance, entry, ("video_id", "id")) or f"{gloss}-{position}"),
+                    "split": _lookup(instance, entry, ("split", "subset")),
+                    "source_url": _lookup(instance, entry, SOURCE_URL_KEYS),
+                    "frame_start": _optional_int(_lookup(instance, entry, ("frame_start", "start_frame"))),
+                    "frame_end": _optional_int(_lookup(instance, entry, ("frame_end", "end_frame"))),
+                    "sequence_path": str(sequence_path) if sequence_path else None,
+                    "sequence_exists": bool(sequence_path and sequence_path.exists()),
+                    "metadata": {
+                        key: instance[key]
+                        for key in METADATA_KEYS
+                        if key in instance and instance[key] is not None
+                    },
+                }
+            )
+
+    return manifests
+
+
+def write_wlasl_manifest(
+    index_path: Path,
+    out_path: Path,
+    samples_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Write a Loru WLASL manifest JSON file and return its entries."""
+    manifest = load_wlasl_manifest(index_path, samples_dir=samples_dir)
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return manifest
+
+
+def _index_entries(payload: object) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [entry for entry in payload if isinstance(entry, dict)]
+    if isinstance(payload, dict):
+        entries = payload.get("entries") or payload.get("data")
+        if isinstance(entries, list):
+            return [entry for entry in entries if isinstance(entry, dict)]
+        return [payload]
+    return []
+
+
+def _lookup(
+    primary: dict[str, Any],
+    fallback: dict[str, Any] | tuple[()],
+    keys: tuple[str, ...],
+) -> Any:
+    for key in keys:
+        if key in primary and primary[key] is not None:
+            return primary[key]
+    if isinstance(fallback, dict):
+        for key in keys:
+            if key in fallback and fallback[key] is not None:
+                return fallback[key]
+    return None
+
+
+def _resolve_sequence_path(
+    instance: dict[str, Any],
+    index_root: Path,
+    gloss: str,
+    samples_dir: Path | None,
+) -> Path | None:
+    for key in SEQUENCE_PATH_KEYS:
+        raw_path = instance.get(key)
+        if raw_path:
+            path = Path(str(raw_path))
+            return path if path.is_absolute() else (index_root / path).resolve()
+
+    if samples_dir is None:
+        return None
+
+    path = Path(samples_dir) / f"{gloss}.json"
+    return path if path.is_absolute() else path.resolve()
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/tests/fixtures/wlasl_index.json
+++ b/tests/fixtures/wlasl_index.json
@@ -1,0 +1,27 @@
+[
+  {
+    "gloss": "Thank You",
+    "instances": [
+      {
+        "video_id": "wlasl-thank-you-001",
+        "url": "https://example.invalid/wlasl/thank-you.mp4",
+        "split": "train",
+        "frame_start": 1,
+        "frame_end": 48
+      }
+    ]
+  },
+  {
+    "gloss": "HELLO",
+    "instances": [
+      {
+        "video_id": "wlasl-hello-001",
+        "url": "https://example.invalid/wlasl/hello.mp4",
+        "split": "test",
+        "frame_start": 3,
+        "frame_end": 34,
+        "sequence_path": "../../data/samples/hello.json"
+      }
+    ]
+  }
+]

--- a/tests/test_wlasl_adapter.py
+++ b/tests/test_wlasl_adapter.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from loru.cli import app
+from loru.data.wlasl import load_wlasl_manifest, write_wlasl_manifest
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_load_wlasl_manifest_normalizes_entries() -> None:
+    manifest = load_wlasl_manifest(FIXTURES / "wlasl_index.json", samples_dir=Path("data/samples"))
+
+    assert [entry["gloss"] for entry in manifest] == ["thank_you", "hello"]
+    assert manifest[0]["video_id"] == "wlasl-thank-you-001"
+    assert manifest[0]["split"] == "train"
+    assert manifest[0]["source_url"] == "https://example.invalid/wlasl/thank-you.mp4"
+    assert manifest[0]["sequence_path"].endswith("data/samples/thank_you.json")
+    assert manifest[0]["sequence_exists"] is True
+    assert manifest[0]["frame_start"] == 1
+    assert manifest[0]["frame_end"] == 48
+
+    assert manifest[1]["gloss"] == "hello"
+    assert manifest[1]["sequence_path"].endswith("data/samples/hello.json")
+    assert manifest[1]["sequence_exists"] is True
+
+
+def test_write_wlasl_manifest_outputs_loru_manifest(tmp_path: Path) -> None:
+    out = tmp_path / "manifest.json"
+
+    write_wlasl_manifest(FIXTURES / "wlasl_index.json", out, samples_dir=Path("data/samples"))
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload[0]["dataset"] == "wlasl"
+    assert payload[0]["gloss"] == "thank_you"
+
+
+def test_wlasl_manifest_cli_writes_manifest(tmp_path: Path) -> None:
+    out = tmp_path / "manifest.json"
+    result = CliRunner().invoke(
+        app,
+        [
+            "data",
+            "wlasl-manifest",
+            "--index",
+            str(FIXTURES / "wlasl_index.json"),
+            "--samples-dir",
+            "data/samples",
+            "--out",
+            str(out),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "WLASL manifest" in result.output
+    assert json.loads(out.read_text(encoding="utf-8"))[1]["gloss"] == "hello"


### PR DESCRIPTION
## Summary
- Adds a WLASL-style index adapter that normalizes source gloss names into Loru sequence metadata.
- Wires a `loru data wlasl-manifest` CLI command for printing or writing the converted manifest.
- Adds a fixture and tests covering manifest normalization, JSON output, and the CLI path.

## Linked issue / bounty
Closes #6.

## Problem
Loru has local landmark samples, but it did not have a small bridge for WLASL-style index metadata. That made it harder to map WLASL records onto Loru sample paths for dataset preparation and smoke validation.

## Fix
The new adapter loads WLASL-like JSON records, normalizes gloss names such as `Thank You` into Loru-style identifiers such as `thank_you`, preserves useful source metadata, and reports whether a matching local sequence file exists. The CLI can emit the manifest directly or write it to disk with `--out`.

## Verification
- `git diff --check origin/master...HEAD`
- `ruff check src tests`
- `pytest -q` -> 20 passed, 1 warning
- `PYTHONPATH=src python3 -m loru.cli data wlasl-manifest --index tests/fixtures/wlasl_index.json --samples-dir data/samples` -> emitted normalized `thank_you` and `hello` manifest entries with `sequence_exists: true`

## Risk and rollback
- Risk is limited to a new dataset-helper path plus CLI registration; existing demo/train/infer behavior is unchanged.
- Rollback is a clean revert of this PR if the manifest shape should use different field names.

## Maintainer notes
- No external WLASL data is downloaded by this change; the fixture is synthetic metadata for adapter coverage.
- Happy to adjust the manifest field names or CLI naming if the project prefers a different convention.