### PR TITLE
Document unique synthetic gloss frames

### DIFF
--- a/data/samples/README.md
+++ b/data/samples/README.md
@@ -10,6 +10,7 @@ Synthetic landmark JSON for the offline toy classifier.
 | `source` | `synthetic-scaffold` — not real signer video |
 
 These are **not** real sign language recordings. Replace with consented / licensed corpora via bounties.
+See [Gloss sample notes](../../docs/GLOSS_SAMPLE_NOTES.md) for the unique-frame rule and seed formula for synthetic samples.
 
 ## Cycle 2026-07-14b
 

--- a/docs/GLOSS_SAMPLE_NOTES.md
+++ b/docs/GLOSS_SAMPLE_NOTES.md
@@ -4,6 +4,27 @@ Synthetic samples under data/samples/ are used for offline eval.
 Each JSON needs a unique gloss matching training expectations.
 Do not clone frames with a renamed gloss — eval accuracy will drop.
 
+## Unique-frame rule
+
+Every synthetic gloss needs its own landmark trajectory, not a copied frame pack
+with only the `gloss` field renamed. The toy classifier learns from frame-level
+landmark shape, motion, and summary statistics. If two labels share the same or
+near-identical frames, train/eval splits can reward memorized duplicates or force
+the evaluator to choose between indistinguishable labels, which makes reported
+accuracy look unstable instead of measuring whether a gloss has a distinct
+sample.
+
+Use a deterministic seed per gloss before generating offsets, phase shifts, or
+spiral paths. A simple formula is:
+
+```text
+seed = sha256("demo-asl:{gloss}:{cycle_id}").hexdigest()[0:8]
+phase = int(seed, 16) / 0xffffffff
+```
+
+Then feed `phase` into the synthetic generator so each gloss gets repeatable but
+different landmark offsets and motion over the same frame count.
+
 Cycle 2026-07-14h: later, tomorrow, yesterday promoted into DEFAULT_GLOSS (unique frame packs only).
 
 Cycle 2026-07-14i: outside gloss with unique synthetic frames (hash-offset spiral; do not clone renamed packs).


### PR DESCRIPTION
## Summary
- Documents why cloned or renamed synthetic gloss frames hurt evaluation accuracy.
- Adds a deterministic seed formula for generating unique repeatable landmark trajectories.
- Links the sample README to the gloss sample notes so future contributors can find the rule.

## Linked issue / bounty
Fixes #238

## Problem
Synthetic gloss samples can look valid by filename and `gloss` value while reusing nearly identical landmark frames. That can make train/eval results unstable because labels are not backed by distinct trajectories.

## Fix
- Added a `Unique-frame rule` section to `docs/GLOSS_SAMPLE_NOTES.md`.
- Added an example seed/phase formula for repeatable per-gloss generation.
- Linked `data/samples/README.md` to the notes.

## Verification
- `python3 -m pytest tests/test_eval.py tests/test_loader.py -q` -> 5 passed.
- `ruff check src tests` -> all checks passed.
- `python3 -m pytest -q` -> 20 passed, 1 existing Starlette/FastAPI deprecation warning.
- `git diff --check origin/master..HEAD` -> passed.

## Risk and rollback
Docs-only change, so runtime risk is low. Reverting this PR removes the documentation link and the unique-frame guidance without changing code or data.

## Maintainer notes
The seed formula is illustrative documentation and is not wired into a generator in this PR.