### PR TITLE
Add near-duplicate gloss frame detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Demo writes audio under the configured output directory (e.g. `demo_hello.wav`).
 | `loru demo` | Train smoke + infer text + voice on `hello` |
 | `loru gui` / `loru-gui` | **Qt desktop app** (needs `.[gui]`) |
 | `loru data list` | Landmark sample files |
+| `loru data duplicates` | Near-duplicate gloss frame detector |
 | `loru infer demo -s hello` | Gloss → sentence |
 | `loru infer text …` | Sign file → text |
 | `loru train` / `eval` | Toy train + evaluation |
@@ -122,6 +123,7 @@ Demo writes audio under the configured output directory (e.g. `demo_hello.wav`).
 
 ```powershell
 loru infer demo --sign thank_you
+loru data duplicates --directory data/samples
 loru demo
 loru-gui
 ```
@@ -194,9 +196,12 @@ docs/diagrams/
 ```powershell
 pytest -q
 ruff check src tests
+loru data duplicates --directory data/samples
 loru demo
 python scripts/capture_gui_shots.py   # refresh GUI screenshots
 ```
+
+Use `--fail-on-match` in CI or pytest fixtures when duplicate gloss frames should block a dataset update.
 
 ---
 

--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -10,6 +10,7 @@ from rich.table import Table
 
 from loru import __version__
 from loru.config import OUT_DIR, RUNS_DIR, SAMPLES_DIR
+from loru.data.duplicates import find_near_duplicate_glosses
 from loru.data.loader import list_sample_files, sequence_summary
 from loru.data.stats import compute_sequence_stats, detect_outliers, print_stats_table, print_outliers_table, print_summary
 from loru.data.wlasl import load_wlasl_manifest, write_wlasl_manifest
@@ -164,6 +165,48 @@ def data_coverage() -> None:
         table.add_row(g, "yes" if ok else "no")
     console.print(table)
     console.print(f"[dim]{have}/{len(DEFAULT_GLOSS)} glosses have samples[/dim]")
+
+
+@data_app.command("duplicates")
+def data_duplicates(
+    directory: Path | None = typer.Option(None, "--directory", "-d", file_okay=False),
+    threshold: float = typer.Option(0.9, "--threshold", min=0.0, max=1.0),
+    max_offset: int = typer.Option(4, "--max-offset", min=0),
+    min_overlap: int = typer.Option(4, "--min-overlap", min=1),
+    decimals: int = typer.Option(3, "--decimals", min=0, max=8),
+    fail_on_match: bool = typer.Option(False, "--fail-on-match"),
+) -> None:
+    """Detect near-duplicate gloss frame sequences by rounded frame hashes."""
+    files = list_sample_files(directory)
+    matches = find_near_duplicate_glosses(
+        files,
+        threshold=threshold,
+        max_offset=max_offset,
+        min_overlap=min_overlap,
+        decimals=decimals,
+    )
+    if not matches:
+        console.print("[green]No near-duplicate gloss frame sequences detected.[/green]")
+        return
+
+    table = Table(title=f"Near-duplicate gloss frames ({len(matches)})")
+    table.add_column("Left")
+    table.add_column("Right")
+    table.add_column("Score", justify="right")
+    table.add_column("Offset", justify="right")
+    table.add_column("Overlap", justify="right")
+    for match in matches:
+        table.add_row(
+            Path(match["left"]).name,
+            Path(match["right"]).name,
+            f"{match['score']:.3f}",
+            str(match["offset"]),
+            str(match["overlap"]),
+        )
+    console.print(table)
+    console.print_json(data={"matches": matches})
+    if fail_on_match:
+        raise typer.Exit(1)
 
 
 @data_app.command("wlasl-manifest")

--- a/src/loru/data/duplicates.py
+++ b/src/loru/data/duplicates.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+from loru.data.loader import load_sequence
+
+
+def frame_hashes(frames: np.ndarray, decimals: int = 3) -> list[str]:
+    """Return stable per-frame hashes after rounding landmark coordinates."""
+    if frames.ndim < 2 or frames.shape[0] == 0:
+        return []
+    rounded = np.round(frames.reshape(frames.shape[0], -1), decimals=decimals)
+    hashes = []
+    for row in rounded:
+        digest = hashlib.sha256(row.tobytes()).hexdigest()
+        hashes.append(digest[:16])
+    return hashes
+
+
+def best_offset_match(
+    left: list[str],
+    right: list[str],
+    *,
+    max_offset: int = 4,
+    min_overlap: int = 4,
+) -> dict:
+    """Find the best shifted frame-hash match between two sequences."""
+    best = {"offset": 0, "overlap": 0, "matches": 0, "score": 0.0}
+    if not left or not right:
+        return best
+
+    for offset in range(-max_offset, max_offset + 1):
+        if offset >= 0:
+            left_start = offset
+            right_start = 0
+        else:
+            left_start = 0
+            right_start = -offset
+        overlap = min(len(left) - left_start, len(right) - right_start)
+        if overlap < min_overlap:
+            continue
+        matches = sum(
+            1
+            for i in range(overlap)
+            if left[left_start + i] == right[right_start + i]
+        )
+        score = matches / overlap
+        if (score, matches, overlap) > (best["score"], best["matches"], best["overlap"]):
+            best = {
+                "offset": offset,
+                "overlap": overlap,
+                "matches": matches,
+                "score": score,
+            }
+    return best
+
+
+def find_near_duplicate_glosses(
+    files: Iterable[Path],
+    *,
+    threshold: float = 0.9,
+    max_offset: int = 4,
+    min_overlap: int = 4,
+    decimals: int = 3,
+) -> list[dict]:
+    """Report pairs whose rounded frame sequences are near-identical."""
+    loaded = []
+    for path in sorted(Path(p) for p in files):
+        gloss, frames = load_sequence(path)
+        loaded.append(
+            {
+                "path": path,
+                "gloss": gloss,
+                "hashes": frame_hashes(frames, decimals=decimals),
+                "frames": int(frames.shape[0]) if frames.ndim >= 1 else 0,
+            }
+        )
+
+    matches = []
+    for i, left in enumerate(loaded):
+        for right in loaded[i + 1 :]:
+            result = best_offset_match(
+                left["hashes"],
+                right["hashes"],
+                max_offset=max_offset,
+                min_overlap=min_overlap,
+            )
+            if result["score"] >= threshold:
+                matches.append(
+                    {
+                        "left": str(left["path"]),
+                        "right": str(right["path"]),
+                        "left_gloss": left["gloss"],
+                        "right_gloss": right["gloss"],
+                        "left_frames": left["frames"],
+                        "right_frames": right["frames"],
+                        "offset": result["offset"],
+                        "overlap": result["overlap"],
+                        "matching_frames": result["matches"],
+                        "score": round(result["score"], 4),
+                    }
+                )
+    return sorted(matches, key=lambda m: (-m["score"], m["left"], m["right"]))
+
+
+def assert_no_near_duplicate_glosses(
+    files: Iterable[Path],
+    *,
+    threshold: float = 0.9,
+    max_offset: int = 4,
+    min_overlap: int = 4,
+    decimals: int = 3,
+) -> None:
+    matches = find_near_duplicate_glosses(
+        files,
+        threshold=threshold,
+        max_offset=max_offset,
+        min_overlap=min_overlap,
+        decimals=decimals,
+    )
+    if not matches:
+        return
+    details = ", ".join(
+        f"{Path(m['left']).name}<->{Path(m['right']).name} score={m['score']} offset={m['offset']}"
+        for m in matches[:5]
+    )
+    raise AssertionError(f"near-duplicate gloss frames detected: {details}")

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from loru.data.duplicates import (
+    assert_no_near_duplicate_glosses,
+    best_offset_match,
+    find_near_duplicate_glosses,
+    frame_hashes,
+)
+
+
+def write_sequence(path: Path, gloss: str, frames: list) -> Path:
+    path.write_text(
+        json.dumps({"gloss": gloss, "fps": 15, "frames": frames}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def make_frames(start: float, count: int = 8) -> list:
+    frames = []
+    for i in range(count):
+        base = start + i * 0.01
+        frames.append(
+            [
+                [base, base + 0.1, base + 0.2],
+                [base + 0.3, base + 0.4, base + 0.5],
+            ]
+        )
+    return frames
+
+
+def test_frame_hashes_are_stable_after_rounding() -> None:
+    frames = make_frames(0.1, count=2)
+    hashes = frame_hashes(np.asarray(frames), decimals=3)
+    nudged = frame_hashes(np.asarray(frames) + 0.0001, decimals=3)
+    assert hashes == nudged
+    assert len(set(hashes)) == 2
+
+
+def test_best_offset_match_finds_shifted_clone() -> None:
+    left = ["a", "b", "c", "d", "e"]
+    right = ["x", "b", "c", "d", "e"]
+    result = best_offset_match(left, right, max_offset=2, min_overlap=3)
+    assert result["offset"] == 0
+    assert result["matches"] == 4
+    assert result["score"] == 0.8
+
+
+def test_find_near_duplicate_glosses_reports_synthetic_clone(tmp_path: Path) -> None:
+    original = make_frames(0.1, count=8)
+    clone_with_offset = make_frames(9.0, count=1) + original
+    unrelated = make_frames(1.5, count=8)
+
+    a = write_sequence(tmp_path / "hello.json", "hello", original)
+    b = write_sequence(tmp_path / "hello_clone.json", "hello_clone", clone_with_offset)
+    c = write_sequence(tmp_path / "thanks.json", "thanks", unrelated)
+
+    matches = find_near_duplicate_glosses([a, b, c], threshold=0.9, max_offset=2)
+
+    assert len(matches) == 1
+    assert matches[0]["left"].endswith("hello.json")
+    assert matches[0]["right"].endswith("hello_clone.json")
+    assert matches[0]["offset"] == 0 or matches[0]["offset"] == -1
+    assert matches[0]["score"] >= 0.9
+
+
+def test_assert_no_near_duplicate_glosses_fails_on_clone(tmp_path: Path) -> None:
+    original = write_sequence(tmp_path / "a.json", "a", make_frames(0.2, count=6))
+    clone = write_sequence(tmp_path / "b.json", "b", make_frames(0.2, count=6))
+
+    with pytest.raises(AssertionError, match="near-duplicate gloss frames detected"):
+        assert_no_near_duplicate_glosses([original, clone])
+
+
+def test_assert_no_near_duplicate_glosses_allows_distinct_sequences(tmp_path: Path) -> None:
+    a = write_sequence(tmp_path / "a.json", "a", make_frames(0.2, count=6))
+    b = write_sequence(tmp_path / "b.json", "b", make_frames(2.2, count=6))
+
+    assert_no_near_duplicate_glosses([a, b])


### PR DESCRIPTION
## Summary
- add a rounded frame-hash detector for near-duplicate gloss JSON sequences
- expose it as loru data duplicates with threshold, offset, overlap, rounding, and --fail-on-match options
- add pytest coverage with synthetic clones, shifted clones, and distinct sequences
- document the CLI command in the README

Fixes #246

## Verification
- git diff --check
- uv run --python 3.11 --extra dev ruff check src tests
- uv run --python 3.11 --extra dev pytest -q
- uv run --python 3.11 --extra dev loru data duplicates --directory data/samples

## Evidence
The CLI smoke found 16 near-duplicate pairs in bundled samples, including hello.json <-> maybe.json and later.json <-> tomorrow.json at score 1.000.