### PR TITLE
Add evaluation metrics report

### DIFF
--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -13,6 +13,7 @@ from loru.config import OUT_DIR, RUNS_DIR, SAMPLES_DIR
 from loru.data.loader import list_sample_files, sequence_summary
 from loru.data.stats import compute_sequence_stats, detect_outliers, print_stats_table, print_outliers_table, print_summary
 from loru.data.wlasl import load_wlasl_manifest, write_wlasl_manifest
+from loru.eval.metrics import confusion_matrix_table, evaluate_samples
 from loru.infer.pipeline import sign_to_voice
 from loru.infer.text import gloss_to_sentence, multi_gloss_to_sentence, sign_to_text
 from loru.models.vocab import DEFAULT_GLOSS
@@ -300,6 +301,41 @@ def eval_toy() -> None:
     (RUNS_DIR / "eval_toy.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
     if acc < 0.8:
         raise typer.Exit(1)
+
+
+@eval_app.command("report")
+def eval_report(
+    out: Path = typer.Option(
+        Path("data/runs/metrics.json"),
+        "--out",
+        "-o",
+        help="Output metrics JSON path.",
+    ),
+    samples_dir: Path | None = typer.Option(
+        None,
+        "--samples-dir",
+        file_okay=False,
+        help="Directory of local sample JSON files.",
+    ),
+) -> None:
+    """Write top-k accuracy and confusion matrix metrics for local samples."""
+    files = list_sample_files(samples_dir)
+    if not files:
+        console.print("[yellow]No samples[/yellow]")
+        raise typer.Exit(1)
+
+    report = evaluate_samples(files)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    summary = Table(title="Evaluation report")
+    summary.add_column("metric")
+    summary.add_column("value", justify="right")
+    for name, value in report["top_k_accuracy"].items():
+        summary.add_row(name, f"{value:.4f}")
+    console.print(summary)
+    console.print(confusion_matrix_table(report["confusion_matrix"], report["labels"]))
+    console.print(f"[green]metrics written[/green] {out}")
 
 
 @train_app.command("toy")

--- a/src/loru/eval/__init__.py
+++ b/src/loru/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Evaluation helpers for Loru."""

--- a/src/loru/eval/metrics.py
+++ b/src/loru/eval/metrics.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from rich.table import Table
+
+from loru.data.loader import load_sequence
+from loru.models.toy import ToySignClassifier
+
+
+def top_k_hit(true_label: str, predicted_labels: Sequence[str], k: int) -> bool:
+    """Return whether true_label appears in the first k predicted labels."""
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    return true_label in list(predicted_labels)[:k]
+
+
+def top_k_accuracy(y_true: Sequence[str], y_pred_ranked: Sequence[Sequence[str]], k: int) -> float:
+    """Compute top-k accuracy from true labels and ranked prediction labels."""
+    if len(y_true) != len(y_pred_ranked):
+        raise ValueError("y_true and y_pred_ranked must have the same length")
+    if not y_true:
+        return 0.0
+    hits = sum(1 for true, ranked in zip(y_true, y_pred_ranked) if top_k_hit(true, ranked, k))
+    return hits / len(y_true)
+
+
+def confusion_matrix(
+    y_true: Sequence[str],
+    y_pred: Sequence[str],
+    labels: Sequence[str] | None = None,
+) -> dict[str, dict[str, int]]:
+    """Build a row=true, column=predicted confusion matrix."""
+    if len(y_true) != len(y_pred):
+        raise ValueError("y_true and y_pred must have the same length")
+    ordered = list(labels) if labels is not None else sorted(set(y_true) | set(y_pred))
+    matrix: dict[str, dict[str, int]] = {
+        label: {pred: 0 for pred in ordered}
+        for label in ordered
+    }
+    for true, pred in zip(y_true, y_pred):
+        matrix.setdefault(true, {label: 0 for label in ordered})
+        if pred not in matrix[true]:
+            for row in matrix.values():
+                row.setdefault(pred, 0)
+        matrix[true][pred] += 1
+    return matrix
+
+
+def evaluate_samples(
+    sample_paths: Iterable[Path],
+    k_values: Sequence[int] = (1, 3, 5),
+) -> dict[str, Any]:
+    """Evaluate the toy classifier over local sample files."""
+    files = sorted(sample_paths)
+    if not files:
+        return {
+            "n": 0,
+            "labels": [],
+            "top_k_accuracy": {},
+            "confusion_matrix": {},
+            "samples": [],
+        }
+
+    max_k = max(k_values) if k_values else 1
+    classifier = ToySignClassifier.from_samples(files)
+    rows: list[dict[str, Any]] = []
+    y_true: list[str] = []
+    ranked_labels: list[list[str]] = []
+
+    for path in files:
+        true_label, frames = load_sequence(path)
+        ranked = classifier.predict_top_k(frames, k=max_k)
+        predictions = [
+            {"gloss": gloss, "confidence": round(confidence, 4)}
+            for gloss, confidence in ranked
+        ]
+        labels = [item["gloss"] for item in predictions]
+        y_true.append(true_label)
+        ranked_labels.append(labels)
+        rows.append(
+            {
+                "file": path.name,
+                "true_gloss": true_label,
+                "predicted_gloss": labels[0] if labels else "unknown",
+                "top_predictions": predictions,
+            }
+        )
+
+    labels = sorted(set(y_true) | {row["predicted_gloss"] for row in rows})
+    top_k = {
+        f"top_{k}": round(top_k_accuracy(y_true, ranked_labels, k), 4)
+        for k in k_values
+    }
+    return {
+        "n": len(rows),
+        "labels": labels,
+        "top_k_accuracy": top_k,
+        "confusion_matrix": confusion_matrix(
+            y_true,
+            [row["predicted_gloss"] for row in rows],
+            labels=labels,
+        ),
+        "samples": rows,
+    }
+
+
+def confusion_matrix_table(matrix: dict[str, dict[str, int]], labels: Sequence[str]) -> Table:
+    """Render non-zero confusion matrix cells as a compact Rich table."""
+    table = Table(title="Confusion matrix")
+    table.add_column("true")
+    table.add_column("predicted")
+    table.add_column("count", justify="right")
+    for true_label in labels:
+        row = matrix.get(true_label, {})
+        for pred_label in labels:
+            count = row.get(pred_label, 0)
+            if count:
+                table.add_row(true_label, pred_label, str(count))
+    return table

--- a/src/loru/models/toy.py
+++ b/src/loru/models/toy.py
@@ -41,20 +41,25 @@ class ToySignClassifier:
         return cls(prototypes)
 
     def predict(self, frames: np.ndarray) -> tuple[str, float]:
-        if frames.size == 0:
+        ranked = self.predict_top_k(frames, k=1)
+        if not ranked:
             return "unknown", 0.0
+        return ranked[0]
+
+    def predict_top_k(self, frames: np.ndarray, k: int = 3) -> list[tuple[str, float]]:
+        if frames.size == 0:
+            return []
         feature = frames.reshape(frames.shape[0], -1).mean(axis=0)
-        best_gloss = "unknown"
-        best_score = -1e18
+        scored: list[tuple[str, float]] = []
         for gloss, proto in self.prototypes.items():
             # cosine similarity with zero-safe norm
             a = feature
             b = proto
             denom = (np.linalg.norm(a) * np.linalg.norm(b)) + 1e-9
             score = float(np.dot(a, b) / denom)
-            if score > best_score:
-                best_score = score
-                best_gloss = gloss
-        # map raw cosine [-1,1] roughly into [0,1]
-        confidence = max(0.0, min(1.0, (best_score + 1.0) / 2.0))
-        return id_to_gloss(DEFAULT_GLOSS.index(best_gloss)) if best_gloss in DEFAULT_GLOSS else best_gloss, confidence
+            # map raw cosine [-1,1] roughly into [0,1]
+            confidence = max(0.0, min(1.0, (score + 1.0) / 2.0))
+            label = id_to_gloss(DEFAULT_GLOSS.index(gloss)) if gloss in DEFAULT_GLOSS else gloss
+            scored.append((label, confidence))
+        scored.sort(key=lambda item: item[1], reverse=True)
+        return scored[: max(1, k)]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from loru.data.loader import list_sample_files
+from loru.eval.metrics import (
+    confusion_matrix,
+    confusion_matrix_table,
+    evaluate_samples,
+    top_k_accuracy,
+    top_k_hit,
+)
+
+
+def test_top_k_helpers() -> None:
+    ranked = [["cat", "dog", "bird"], ["red", "green", "blue"]]
+    assert top_k_hit("dog", ranked[0], k=2)
+    assert not top_k_hit("bird", ranked[0], k=2)
+    assert top_k_accuracy(["dog", "blue"], ranked, k=3) == 1.0
+    assert top_k_accuracy(["dog", "blue"], ranked, k=1) == 0.0
+
+
+def test_confusion_matrix_counts() -> None:
+    matrix = confusion_matrix(
+        ["hello", "hello", "thanks"],
+        ["hello", "thanks", "thanks"],
+        labels=["hello", "thanks"],
+    )
+    assert matrix["hello"]["hello"] == 1
+    assert matrix["hello"]["thanks"] == 1
+    assert matrix["thanks"]["thanks"] == 1
+
+
+def test_evaluate_samples_report_shape() -> None:
+    report = evaluate_samples(list_sample_files()[:5], k_values=(1, 3))
+    assert report["n"] == 5
+    assert set(report["top_k_accuracy"]) == {"top_1", "top_3"}
+    assert report["top_k_accuracy"]["top_3"] >= report["top_k_accuracy"]["top_1"]
+    assert report["samples"][0]["top_predictions"]
+    table = confusion_matrix_table(report["confusion_matrix"], report["labels"])
+    assert table.title == "Confusion matrix"


### PR DESCRIPTION
## Summary
- add reusable top-k accuracy and confusion matrix helpers
- add loru eval report --out data/runs/metrics.json for JSON metrics output
- print top-k summary and compact Rich confusion matrix table in the CLI

Fixes #8

## Validation
- git diff --check
- uv run --python 3.11 --extra dev ruff check src tests
- uv run --python 3.11 --extra dev pytest -q -> 21 passed, 1 skipped
- uv run --python 3.11 loru eval report --out data/runs/metrics.json -> top_1=0.8793, top_3=0.9483, top_5=1.0000