### PR TITLE
Add offline gloss sample comparison CLI

### DIFF
--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -26,10 +26,12 @@ data_app = typer.Typer(help="Dataset helpers")
 infer_app = typer.Typer(help="Inference (sign→text / sign→voice)")
 train_app = typer.Typer(help="Training")
 eval_app = typer.Typer(help="Evaluation")
+gloss_app = typer.Typer(help="Inspect and compare gloss samples")
 app.add_typer(data_app, name="data")
 app.add_typer(infer_app, name="infer")
 app.add_typer(train_app, name="train")
 app.add_typer(eval_app, name="eval")
+app.add_typer(gloss_app, name="gloss")
 console = Console()
 
 
@@ -235,6 +237,21 @@ def data_list() -> None:
         summary = sequence_summary(path)
         table.add_row(path.name, summary["gloss"], str(summary["frames"]))
     console.print(table)
+
+
+@gloss_app.command("compare")
+def gloss_compare(
+    sample_a: Path = typer.Option(..., "--a", exists=True, dir_okay=False),
+    sample_b: Path = typer.Option(..., "--b", exists=True, dir_okay=False),
+) -> None:
+    """Compare frame counts and a crude time-aligned landmark distance."""
+    from loru.data.compare import compare_gloss_samples
+
+    try:
+        console.print_json(data=compare_gloss_samples(sample_a, sample_b))
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
 
 
 @infer_app.command("demo")

--- a/src/loru/data/compare.py
+++ b/src/loru/data/compare.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from loru.data.loader import load_sequence
+
+
+def _aligned_frames(frames: np.ndarray, count: int) -> np.ndarray:
+    indices = np.linspace(0, frames.shape[0] - 1, num=count).round().astype(int)
+    return frames[indices].reshape(count, -1)
+
+
+def compare_gloss_samples(sample_a: Path, sample_b: Path) -> dict:
+    """Return a deterministic frame and landmark-distance summary for two samples."""
+    gloss_a, frames_a = load_sequence(sample_a)
+    gloss_b, frames_b = load_sequence(sample_b)
+    if frames_a.size == 0 or frames_b.size == 0:
+        raise ValueError("both samples must contain at least one frame")
+
+    feature_dim_a = frames_a[0].size
+    feature_dim_b = frames_b[0].size
+    if feature_dim_a != feature_dim_b:
+        raise ValueError(
+            f"samples have incompatible feature dimensions: {feature_dim_a} and {feature_dim_b}"
+        )
+
+    compared_frames = min(frames_a.shape[0], frames_b.shape[0])
+    aligned_a = _aligned_frames(frames_a, compared_frames)
+    aligned_b = _aligned_frames(frames_b, compared_frames)
+    frame_distances = np.sqrt(np.mean(np.square(aligned_a - aligned_b), axis=1))
+    mean_distance = float(np.mean(frame_distances))
+    max_distance = float(np.max(frame_distances))
+
+    return {
+        "a": {"path": str(sample_a), "gloss": gloss_a, "frames": int(frames_a.shape[0])},
+        "b": {"path": str(sample_b), "gloss": gloss_b, "frames": int(frames_b.shape[0])},
+        "frame_delta": abs(int(frames_a.shape[0]) - int(frames_b.shape[0])),
+        "compared_frames": compared_frames,
+        "mean_landmark_distance": round(mean_distance, 6),
+        "max_landmark_distance": round(max_distance, 6),
+        "possible_clone": gloss_a == gloss_b and mean_distance < 0.001,
+    }

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from loru.cli import app
+from loru.data.compare import compare_gloss_samples
+
+
+def _write_sample(path: Path, gloss: str, frames: list) -> Path:
+    path.write_text(json.dumps({"gloss": gloss, "frames": frames}), encoding="utf-8")
+    return path
+
+
+def test_identical_samples_are_flagged_as_possible_clone(tmp_path: Path) -> None:
+    frames = [[[0.0, 0.0]], [[1.0, 1.0]]]
+    a = _write_sample(tmp_path / "a.json", "hello", frames)
+    b = _write_sample(tmp_path / "b.json", "hello", frames)
+
+    result = compare_gloss_samples(a, b)
+
+    assert result["frame_delta"] == 0
+    assert result["mean_landmark_distance"] == 0.0
+    assert result["possible_clone"] is True
+
+
+def test_different_frame_counts_are_time_aligned(tmp_path: Path) -> None:
+    a = _write_sample(tmp_path / "a.json", "hello", [[[0.0]], [[1.0]], [[2.0]]])
+    b = _write_sample(tmp_path / "b.json", "hello", [[[0.0]], [[3.0]]])
+
+    result = compare_gloss_samples(a, b)
+
+    assert result["frame_delta"] == 1
+    assert result["compared_frames"] == 2
+    assert result["mean_landmark_distance"] == 0.5
+    assert result["max_landmark_distance"] == 1.0
+
+
+def test_incompatible_landmarks_are_rejected(tmp_path: Path) -> None:
+    a = _write_sample(tmp_path / "a.json", "hello", [[[0.0, 1.0]]])
+    b = _write_sample(tmp_path / "b.json", "hello", [[[0.0, 1.0, 2.0]]])
+
+    with pytest.raises(ValueError, match="incompatible feature dimensions"):
+        compare_gloss_samples(a, b)
+
+
+def test_compare_cli_prints_summary(tmp_path: Path) -> None:
+    a = _write_sample(tmp_path / "a.json", "hello", [[[0.0]], [[1.0]]])
+    b = _write_sample(tmp_path / "b.json", "hello", [[[0.0]], [[1.0]]])
+
+    result = CliRunner().invoke(app, ["gloss", "compare", "--a", str(a), "--b", str(b)])
+
+    assert result.exit_code == 0
+    assert '"mean_landmark_distance": 0.0' in result.stdout
+    assert '"possible_clone": true' in result.stdout


### PR DESCRIPTION
## Summary

- add loru gloss compare --a --b for offline sample inspection
- report frame counts, frame delta, and time-aligned landmark distance statistics
- flag near-identical same-gloss samples as possible clones
- reject empty or incompatible sample shapes with clear errors

## Testing

- pytest -q (22 passed, 1 skipped)
- uff check src tests

Fixes #245