### PR TITLE
Add filtered sample catalog command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Demo writes audio under the configured output directory (e.g. `demo_hello.wav`).
 | `loru demo` | Train smoke + infer text + voice on `hello` |
 | `loru gui` / `loru-gui` | **Qt desktop app** (needs `.[gui]`) |
 | `loru data list` | Landmark sample files |
+| `loru samples list [--gloss TEXT]` | Sample catalog with language and frame counts |
 | `loru infer demo -s hello` | Gloss → sentence |
 | `loru infer text …` | Sign file → text |
 | `loru train` / `eval` | Toy train + evaluation |

--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -23,10 +23,12 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 data_app = typer.Typer(help="Dataset helpers")
+samples_app = typer.Typer(help="Browse local landmark samples")
 infer_app = typer.Typer(help="Inference (sign→text / sign→voice)")
 train_app = typer.Typer(help="Training")
 eval_app = typer.Typer(help="Evaluation")
 app.add_typer(data_app, name="data")
+app.add_typer(samples_app, name="samples")
 app.add_typer(infer_app, name="infer")
 app.add_typer(train_app, name="train")
 app.add_typer(eval_app, name="eval")
@@ -234,6 +236,53 @@ def data_list() -> None:
     for path in files:
         summary = sequence_summary(path)
         table.add_row(path.name, summary["gloss"], str(summary["frames"]))
+    console.print(table)
+
+
+@samples_app.command("list")
+def samples_list(
+    gloss: str | None = typer.Option(
+        None,
+        "--gloss",
+        "-g",
+        help="Case-insensitive gloss substring to include.",
+    ),
+    directory: Path | None = typer.Option(
+        None,
+        "--directory",
+        "-d",
+        exists=True,
+        file_okay=False,
+        help="Custom sample directory. Defaults to data/samples.",
+    ),
+) -> None:
+    """List samples with language and frame counts, optionally filtered by gloss."""
+    query = gloss.strip().lower() if gloss else None
+    rows = []
+    for path in list_sample_files(directory):
+        summary = sequence_summary(path)
+        if query and query not in summary["gloss"]:
+            continue
+        rows.append((path, summary))
+
+    root = directory or SAMPLES_DIR
+    if not rows:
+        detail = f" matching gloss '{gloss}'" if gloss else ""
+        console.print(f"[yellow]No samples{detail} in {root}[/yellow]")
+        raise typer.Exit()
+
+    table = Table(title=f"Samples ({len(rows)})")
+    table.add_column("File")
+    table.add_column("Gloss")
+    table.add_column("Language")
+    table.add_column("Frames", justify="right")
+    for path, summary in rows:
+        table.add_row(
+            path.name,
+            summary["gloss"],
+            summary["language"],
+            str(summary["frames"]),
+        )
     console.print(table)
 
 

--- a/src/loru/data/loader.py
+++ b/src/loru/data/loader.py
@@ -15,18 +15,28 @@ def list_sample_files(directory: Path | None = None) -> list[Path]:
     return sorted(root.glob("*.json"))
 
 
-def load_sequence(path: Path) -> tuple[str, np.ndarray]:
+def _load_payload(path: Path) -> dict:
     payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"sample must be a JSON object: {path}")
+    return payload
+
+
+def load_sequence(path: Path) -> tuple[str, np.ndarray]:
+    payload = _load_payload(path)
     gloss = str(payload.get("gloss") or path.stem).lower()
     frames = np.asarray(payload.get("frames") or [], dtype=np.float64)
     return gloss, frames
 
 
 def sequence_summary(path: Path) -> dict:
-    gloss, frames = load_sequence(path)
+    payload = _load_payload(path)
+    gloss = str(payload.get("gloss") or path.stem).lower()
+    frames = np.asarray(payload.get("frames") or [], dtype=np.float64)
     return {
         "path": str(path),
         "gloss": gloss,
+        "language": str(payload.get("language") or "unknown"),
         "frames": int(frames.shape[0]) if frames.ndim >= 1 else 0,
         "feature_dim": int(frames.reshape(frames.shape[0], -1).shape[1]) if frames.size else 0,
     }

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -18,4 +18,5 @@ def test_load_sequence_shapes() -> None:
     assert frames.shape[0] >= 1
     summary = sequence_summary(path)
     assert summary["gloss"] == gloss
+    assert summary["language"]
     assert summary["frames"] == frames.shape[0]

--- a/tests/test_samples_cli.py
+++ b/tests/test_samples_cli.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from loru.cli import app
+
+
+runner = CliRunner()
+
+
+def _write_sample(directory: Path, name: str, gloss: str, language: str, frame_count: int) -> None:
+    frames = [[[float(index), 0.0, 0.0]] for index in range(frame_count)]
+    payload = {"gloss": gloss, "language": language, "frames": frames}
+    (directory / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_samples_list_filters_by_gloss_and_reports_metadata(tmp_path: Path) -> None:
+    _write_sample(tmp_path, "hello.json", "Hello", "demo-asl", 2)
+    _write_sample(tmp_path, "thanks.json", "thanks", "demo-asl", 3)
+
+    result = runner.invoke(
+        app,
+        ["samples", "list", "--gloss", "HEL", "--directory", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "hello.json" in result.stdout
+    assert "demo-asl" in result.stdout
+    assert "thanks.json" not in result.stdout
+    assert "2" in result.stdout
+
+
+def test_samples_list_reports_empty_filter_result(tmp_path: Path) -> None:
+    _write_sample(tmp_path, "hello.json", "hello", "demo-asl", 1)
+
+    result = runner.invoke(
+        app,
+        ["samples", "list", "--gloss", "missing", "--directory", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert "No samples matching gloss 'missing'" in result.stdout


### PR DESCRIPTION
## Summary

- add `loru samples list` with a case-insensitive `--gloss` filter
- report each sample's language and frame count
- support a custom sample directory for offline inspection
- document the command and add focused CLI coverage

Fixes #237

## Claim

- Issue claim: https://github.com/mergeos-bounties/Loru/issues/237#issuecomment-5002808701
- MergeOS claim queue: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-5002808999
- Reward identity: `github:Wang4F`

## Evidence

Before this change, Loru exposed only `loru data list` and had no `loru samples list --gloss` workflow. After the change:

```text
Samples (1)
File       Gloss  Language  Frames
hello.json hello  demo-asl  8
```

## Verification

- `uv run --frozen --extra dev pytest -q`: 20 passed, 1 skipped
- `uv run --frozen --extra dev ruff check src tests`: passed
- `uv run --frozen loru samples list --gloss hello`: passed
- `git diff --check`: passed
