### PR TITLE
test: cover school sign pack

### DIFF
--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from loru.config import SAMPLES_DIR
 from loru.data.loader import list_sample_files, load_sequence, sequence_summary
+from loru.infer.text import gloss_to_sentence
+from loru.models.vocab import DEFAULT_GLOSS
 
 
 def test_samples_exist() -> None:
@@ -20,3 +22,19 @@ def test_load_sequence_shapes() -> None:
     assert summary["gloss"] == gloss
     assert summary["language"]
     assert summary["frames"] == frames.shape[0]
+
+
+def test_school_sign_pack_has_sample_vocab_and_unique_frames() -> None:
+    path = SAMPLES_DIR / "school.json"
+
+    assert path.exists()
+    assert "school" in DEFAULT_GLOSS
+    assert gloss_to_sentence("school") == "I am at school."
+
+    gloss, frames = load_sequence(path)
+
+    assert gloss == "school"
+    assert frames.ndim == 3
+    assert frames.shape[0] >= 6
+    assert frames.shape[1:] == (21, 3)
+    assert len({frame.tobytes() for frame in frames}) == frames.shape[0]


### PR DESCRIPTION
Fixes #248

## Summary
- adds targeted coverage that the `school` sign pack is bundled as a sample
- verifies `school` is in the default gloss vocabulary and has the expected sentence template
- checks the sample has the expected landmark shape and unique frame payloads

## Validation
- `python -m pytest tests\test_loader.py`
- `python -m pytest`
- `python -m ruff check tests\test_loader.py`