### PR TITLE
feat: validate bundled sample payloads

### DIFF
--- a/src/loru/data/loader.py
+++ b/src/loru/data/loader.py
@@ -4,8 +4,18 @@ import json
 from pathlib import Path
 
 import numpy as np
+from pydantic import BaseModel, Field, ValidationError
 
 from loru.config import SAMPLES_DIR
+
+
+class SamplePayload(BaseModel):
+    """Validated shape for a bundled sign-sequence sample."""
+
+    gloss: str = Field(min_length=1)
+    frames: list[list[list[float]]] = Field(min_length=1)
+    fps: float | None = Field(default=None, gt=0)
+    language: str = "demo-asl"
 
 
 def list_sample_files(directory: Path | None = None) -> list[Path]:
@@ -16,10 +26,15 @@ def list_sample_files(directory: Path | None = None) -> list[Path]:
 
 
 def _load_payload(path: Path) -> dict:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"sample must be a JSON object: {path}")
-    return payload
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"sample must contain valid JSON: {path}") from exc
+
+    try:
+        return SamplePayload.model_validate(payload).model_dump(exclude_none=True)
+    except ValidationError as exc:
+        raise ValueError(f"invalid sample shape in {path}: {exc}") from exc
 
 
 def load_sequence(path: Path) -> tuple[str, np.ndarray]:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import json
+
+import pytest
+
 from loru.config import SAMPLES_DIR
-from loru.data.loader import list_sample_files, load_sequence, sequence_summary
+from loru.data.loader import SamplePayload, list_sample_files, load_sequence, sequence_summary
 
 
 def test_samples_exist() -> None:
@@ -20,3 +24,28 @@ def test_load_sequence_shapes() -> None:
     assert summary["gloss"] == gloss
     assert summary["language"]
     assert summary["frames"] == frames.shape[0]
+
+
+def test_existing_samples_validate_against_the_schema() -> None:
+    for path in list_sample_files():
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        sample = SamplePayload.model_validate(payload)
+        assert sample.gloss
+        assert sample.frames
+
+
+@pytest.mark.parametrize(
+    "payload, error",
+    [
+        ({"gloss": "hello", "frames": []}, "frames"),
+        ({"gloss": "", "frames": [[[0, 1, 2]]]}, "gloss"),
+        ({"gloss": "hello", "frames": [[[0, 1, 2]]], "fps": 0}, "fps"),
+    ],
+)
+def test_invalid_sample_shape_has_helpful_error(tmp_path, payload, error) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid sample shape") as exc_info:
+        load_sequence(path)
+    assert error in str(exc_info.value)


### PR DESCRIPTION
## Summary
- validate sample JSON at the loader boundary with a Pydantic schema
- enforce non-empty gloss and frames plus a positive optional fps
- return clear errors for invalid JSON and invalid sample shapes
- test all bundled samples plus representative invalid payloads

Fixes #4

## Tests
- `python -m pytest tests\\test_loader.py tests\\test_infer.py` (9 passed)