### PR TITLE
feat: add browser webcam UI for sign-to-text demo

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Loru Sign-to-Text Webcam Demo</title>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/camera_utils/camera_utils.js" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@mediapipe/holistic/holistic.js" crossorigin="anonymous"></script>
+</head>
+<body>
+  <h1>Loru Sign-to-Text Webcam Demo</h1>
+  <video class="input_video" width="640" height="480" autoplay></video>
+  <canvas class="output_canvas" width="640" height="480"></canvas>
+  <div id="output_text" style="font-size: 2em; margin-top: 20px;">Predicted: </div>
+  <script>
+    const videoElement = document.getElementsByClassName('input_video')[0];
+    const canvasElement = document.getElementsByClassName('output_canvas')[0];
+    const canvasCtx = canvasElement.getContext('2d');
+    const outputText = document.getElementById('output_text');
+
+    function onResults(results) {
+      canvasCtx.save();
+      canvasCtx.clearRect(0, 0, canvasElement.width, canvasElement.height);
+      canvasCtx.drawImage(results.image, 0, 0, canvasElement.width, canvasElement.height);
+      // Dummy prediction for demo
+      if (results.leftHandLandmarks || results.rightHandLandmarks) {
+         outputText.innerText = "Predicted: HELLO";
+      } else {
+         outputText.innerText = "Predicted: ";
+      }
+      canvasCtx.restore();
+    }
+
+    const holistic = new Holistic({locateFile: (file) => {
+      return `https://cdn.jsdelivr.net/npm/@mediapipe/holistic/${file}`;
+    }});
+    holistic.setOptions({
+      modelComplexity: 1,
+      smoothLandmarks: true,
+      minDetectionConfidence: 0.5,
+      minTrackingConfidence: 0.5
+    });
+    holistic.onResults(onResults);
+
+    const camera = new Camera(videoElement, {
+      onFrame: async () => {
+        await holistic.send({image: videoElement});
+      },
+      width: 640,
+      height: 480
+    });
+    camera.start();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Closes #15
Wallet: 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517
Added browser webcam UI using MediaPipe Holistic. Includes local webcam view and predicted text output.