### PR TITLE
feat: near-duplicate gloss frame detector (#246)

### DIFF
--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -256,6 +256,65 @@ def gloss_compare(
         raise typer.Exit(code=1) from exc
 
 
+@gloss_app.command("find-duplicates")
+def gloss_find_duplicates(
+    directory: Path | None = typer.Option(
+        None,
+        "--directory",
+        "-d",
+        exists=True,
+        file_okay=False,
+        help="Custom samples directory. Defaults to data/samples.",
+    ),
+    threshold: float = typer.Option(
+        0.001,
+        "--threshold",
+        "-t",
+        help="Mean landmark distance below which two same-gloss samples are flagged as near-duplicates.",
+    ),
+    report: bool = typer.Option(False, "--report", "-r", help="Output full report (JSON list)."),
+) -> None:
+    """Scan samples directory for near-duplicate gloss pairs.
+
+    Fails (exit code 1) if any same-gloss pair shares near-identical frame sequences.
+    Designed for use in CI or pre-commit hooks.
+    """
+    from loru.config import SAMPLES_DIR
+    from loru.data.duplicate import find_near_duplicates
+
+    scan_dir = directory or SAMPLES_DIR
+    duplicates = find_near_duplicates(scan_dir, distance_threshold=threshold)
+
+    if not duplicates:
+        console.print(f"[green]No near-duplicates found in {scan_dir}[/green]")
+        return
+
+    # Print summary table
+    table = Table(title=f"Near-duplicate pairs ({len(duplicates)})")
+    table.add_column("Gloss")
+    table.add_column("File A")
+    table.add_column("File B")
+    table.add_column("Mean Dist")
+    table.add_column("Max Dist")
+    table.add_column("Frames Δ")
+    for dup in duplicates:
+        table.add_row(
+            dup.gloss,
+            dup.file_a.name,
+            dup.file_b.name,
+            f"{dup.mean_distance:.6f}",
+            f"{dup.max_distance:.6f}",
+            str(dup.frame_delta),
+        )
+    console.print(table)
+    console.print(f"[red]Found {len(duplicates)} near-duplicate pair(s) — CI should fail[/red]")
+
+    if report:
+        console.print_json(data=[dup.as_dict() for dup in duplicates])
+
+    raise typer.Exit(code=1)
+
+
 @samples_app.command("list")
 def samples_list(
     gloss: str | None = typer.Option(

--- a/src/loru/data/duplicate.py
+++ b/src/loru/data/duplicate.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from loru.data.compare import compare_gloss_samples
+
+
+@dataclass
+class NearDuplicateReport:
+    file_a: Path
+    file_b: Path
+    gloss: str
+    mean_distance: float
+    max_distance: float
+    frame_delta: int
+    is_near_duplicate: bool
+
+    def as_dict(self) -> dict:
+        return {
+            "file_a": str(self.file_a),
+            "file_b": str(self.file_b),
+            "gloss": self.gloss,
+            "mean_distance": self.mean_distance,
+            "max_distance": self.max_distance,
+            "frame_delta": self.frame_delta,
+            "is_near_duplicate": self.is_near_duplicate,
+        }
+
+
+# Threshold: if mean landmark distance is below this, flag as near-duplicate
+# This is deliberately strict — near-identical synthetic frames should be < 0.001
+DISTANCE_THRESHOLD = 0.001
+
+
+def find_near_duplicates(
+    samples_dir: Path,
+    distance_threshold: float = DISTANCE_THRESHOLD,
+) -> list[NearDuplicateReport]:
+    """Scan a directory of gloss JSON files and report near-duplicate pairs.
+
+    Two samples are considered near-duplicates if:
+    - They share the same gloss name, AND
+    - Their mean frame landmark distance is below the threshold
+
+    Returns a list of NearDuplicateReport, one per flagged pair.
+    Skips comparison of a file against itself.
+    """
+    from loru.data.loader import list_sample_files
+
+    files = list_sample_files(samples_dir)
+    reports: list[NearDuplicateReport] = []
+
+    # Compare every pair once (i < j)
+    for i in range(len(files)):
+        for j in range(i + 1, len(files)):
+            path_a = files[i]
+            path_b = files[j]
+            try:
+                result = compare_gloss_samples(path_a, path_b)
+            except (ValueError, KeyError):
+                # Incompatible dimensions or malformed JSON — skip
+                continue
+
+            mean_dist = result["mean_landmark_distance"]
+            gloss = result["a"]["gloss"]
+
+            # Only flag same-gloss pairs as near-duplicates
+            same_gloss = gloss == result["b"]["gloss"]
+            is_near = same_gloss and mean_dist < distance_threshold
+
+            if is_near:
+                reports.append(
+                    NearDuplicateReport(
+                        file_a=path_a,
+                        file_b=path_b,
+                        gloss=gloss,
+                        mean_distance=mean_dist,
+                        max_distance=result["max_landmark_distance"],
+                        frame_delta=result["frame_delta"],
+                        is_near_duplicate=True,
+                    )
+                )
+
+    return reports
+
+
+def has_near_duplicates(
+    samples_dir: Path,
+    distance_threshold: float = DISTANCE_THRESHOLD,
+) -> bool:
+    """Return True if any near-duplicate pair is found (for use in pytest)."""
+    return len(find_near_duplicates(samples_dir, distance_threshold)) > 0

--- a/tests/test_duplicate.py
+++ b/tests/test_duplicate.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from loru.cli import app
+from loru.data.duplicate import (
+    DISTANCE_THRESHOLD,
+    NearDuplicateReport,
+    find_near_duplicates,
+    has_near_duplicates,
+)
+
+
+def _write_sample(path, gloss: str, frames: list) -> None:
+    """Write a synthetic gloss sample JSON."""
+    path.write_text(
+        json.dumps({"gloss": gloss, "frames": frames}),
+        encoding="utf-8",
+    )
+
+
+class TestNearDuplicateDetector:
+    def test_no_duplicates_when_all_unique(self, tmp_path) -> None:
+        """Different glosses should never be flagged."""
+        _write_sample(tmp_path / "hello.json", "hello", [[[0.0]], [[1.0]]])
+        _write_sample(tmp_path / "thanks.json", "thanks", [[[5.0]], [[6.0]]])
+
+        reports = find_near_duplicates(tmp_path)
+        assert reports == []
+        assert has_near_duplicates(tmp_path) is False
+
+    def test_identical_same_gloss_flagged(self, tmp_path) -> None:
+        """Same gloss with identical frames must be flagged."""
+        frames = [[[0.0, 0.0]], [[1.0, 1.0]], [[2.0, 2.0]]]
+        _write_sample(tmp_path / "a.json", "hello", frames)
+        _write_sample(tmp_path / "b.json", "hello", frames)
+
+        reports = find_near_duplicates(tmp_path, distance_threshold=DISTANCE_THRESHOLD)
+        assert len(reports) == 1
+        dup = reports[0]
+        assert dup.gloss == "hello"
+        assert dup.mean_distance == 0.0
+        assert dup.is_near_duplicate is True
+        assert has_near_duplicates(tmp_path) is True
+
+    def test_near_identical_frames_with_small_variance_not_flagged(self, tmp_path) -> None:
+        """Same gloss with small but non-zero variance should NOT be flagged."""
+        # Mean distance ~0.07 — above 0.001 threshold
+        frames_a = [[[0.0, 0.0]], [[1.0, 1.0]]]
+        frames_b = [[[0.1, 0.1]], [[1.1, 1.1]]]
+        _write_sample(tmp_path / "a.json", "hello", frames_a)
+        _write_sample(tmp_path / "b.json", "hello", frames_b)
+
+        reports = find_near_duplicates(tmp_path, distance_threshold=DISTANCE_THRESHOLD)
+        assert reports == []
+
+    def test_different_gloss_same_frames_not_flagged(self, tmp_path) -> None:
+        """Same frames but different gloss names should NOT be flagged."""
+        frames = [[[0.0, 0.0]], [[1.0, 1.0]]]
+        _write_sample(tmp_path / "a.json", "hello", frames)
+        _write_sample(tmp_path / "b.json", "thanks", frames)
+
+        reports = find_near_duplicates(tmp_path)
+        assert reports == []
+
+    def test_incompatible_dimensions_skipped(self, tmp_path) -> None:
+        """Pairs with incompatible landmark dimensions should be skipped gracefully."""
+        _write_sample(tmp_path / "a.json", "hello", [[[0.0, 0.0]]])  # 2D
+        _write_sample(tmp_path / "b.json", "hello", [[[0.0, 0.0, 0.0]]])  # 3D
+
+        # Should not raise — incompatible pairs are skipped
+        reports = find_near_duplicates(tmp_path)
+        assert reports == []
+
+    def test_threshold_parameter(self, tmp_path) -> None:
+        """Increasing threshold should eventually flag near-but-not-identical pairs."""
+        frames_a = [[[0.0, 0.0]], [[1.0, 1.0]]]
+        frames_b = [[[0.01, 0.01]], [[1.01, 1.01]]]  # mean dist ~0.014
+        _write_sample(tmp_path / "a.json", "hello", frames_a)
+        _write_sample(tmp_path / "b.json", "hello", frames_b)
+
+        # Strict: not flagged
+        reports_strict = find_near_duplicates(tmp_path, distance_threshold=0.001)
+        assert reports_strict == []
+
+        # Loose: flagged
+        reports_loose = find_near_duplicates(tmp_path, distance_threshold=0.02)
+        assert len(reports_loose) == 1
+
+    def test_multiple_duplicates(self, tmp_path) -> None:
+        """Multiple near-duplicate pairs should all be reported."""
+        frames = [[[0.0]], [[1.0]]]
+        _write_sample(tmp_path / "a.json", "hello", frames)
+        _write_sample(tmp_path / "b.json", "hello", frames)
+        _write_sample(tmp_path / "c.json", "thanks", frames)  # same frames, different gloss
+
+        # Different gloss, same frames → not a near duplicate
+        reports = find_near_duplicates(tmp_path)
+        assert len(reports) == 1
+        assert reports[0].gloss == "hello"
+
+    def test_report_as_dict(self, tmp_path) -> None:
+        """NearDuplicateReport.as_dict() should return a serialisable dict."""
+        frames = [[[0.0]], [[1.0]]]
+        _write_sample(tmp_path / "a.json", "hello", frames)
+        _write_sample(tmp_path / "b.json", "hello", frames)
+
+        reports = find_near_duplicates(tmp_path)
+        d = reports[0].as_dict()
+        assert isinstance(d, dict)
+        assert d["is_near_duplicate"] is True
+        assert d["gloss"] == "hello"
+
+
+class TestFindDuplicatesCLI:
+    def test_cli_clean_pass(self, tmp_path) -> None:
+        """CLI exits 0 when no duplicates found."""
+        _write_sample(tmp_path / "hello.json", "hello", [[[0.0]], [[1.0]]])
+        _write_sample(tmp_path / "thanks.json", "thanks", [[[5.0]], [[6.0]]])
+
+        result = CliRunner().invoke(
+            app,
+            ["gloss", "find-duplicates", "--directory", str(tmp_path)],
+        )
+        assert result.exit_code == 0
+        assert "No near-duplicates found" in result.stdout
+
+    def test_cli_finds_duplicates_and_fails(self, tmp_path) -> None:
+        """CLI exits 1 and prints a table when duplicates are found."""
+        frames = [[[0.0, 0.0]], [[1.0, 1.0]]]
+        _write_sample(tmp_path / "a.json", "hello", frames)
+        _write_sample(tmp_path / "b.json", "hello", frames)
+
+        result = CliRunner().invoke(
+            app,
+            ["gloss", "find-duplicates", "--directory", str(tmp_path)],
+        )
+        assert result.exit_code == 1
+        assert "Near-duplicate" in result.stdout
+        assert "hello" in result.stdout
+
+    def test_cli_report_flag_outputs_json(self, tmp_path) -> None:
+        """--report flag outputs machine-readable JSON."""
+        frames = [[[0.0]], [[1.0]]]
+        _write_sample(tmp_path / "a.json", "hello", frames)
+        _write_sample(tmp_path / "b.json", "hello", frames)
+
+        result = CliRunner().invoke(
+            app,
+            ["gloss", "find-duplicates", "--directory", str(tmp_path), "--report"],
+        )
+        assert result.exit_code == 1
+        assert '"is_near_duplicate": true' in result.stdout
+        assert '"gloss": "hello"' in result.stdout
+
+    def test_cli_threshold_option(self, tmp_path) -> None:
+        """Custom threshold is respected by CLI."""
+        frames_a = [[[0.0]], [[1.0]]]
+        frames_b = [[[0.005]], [[1.005]]]  # mean dist ≈ 0.007
+        _write_sample(tmp_path / "a.json", "hello", frames_a)
+        _write_sample(tmp_path / "b.json", "hello", frames_b)
+
+        # Default threshold (0.001) — not flagged
+        result_strict = CliRunner().invoke(
+            app,
+            ["gloss", "find-duplicates", "--directory", str(tmp_path), "--threshold", "0.001"],
+        )
+        assert result_strict.exit_code == 0
+
+        # Higher threshold — flagged
+        result_loose = CliRunner().invoke(
+            app,
+            ["gloss", "find-duplicates", "--directory", str(tmp_path), "--threshold", "0.02"],
+        )
+        assert result_loose.exit_code == 1

--- a/uv.lock
+++ b/uv.lock
@@ -114,43 +114,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "loru"
-version = "0.3.62"
+version = "0.3.64"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
## Summary

Implements **Loru#246**: near-duplicate gloss frame detector. A script/pytest helper that fails when two gloss files share near-identical frame sequences.

## Changes

- **`src/loru/data/duplicate.py`** — new module with:
  - `find_near_duplicates(samples_dir, threshold)` — returns a list of `NearDuplicateReport` for every same-gloss pair whose mean frame landmark distance is below the threshold
  - `has_near_duplicates(samples_dir, threshold)` — returns `True` if any near-duplicate is found (useful for pytest assertions)
  - `DISTANCE_THRESHOLD = 0.001` — default strict threshold for identical synthetic frames

- **`src/loru/cli.py`** — new `loru gloss find-duplicates` subcommand:
  - `--directory` — custom samples directory (default: `data/samples`)
  - `--threshold` — configurable distance threshold (default: `0.001`)
  - `--report` — outputs machine-readable JSON list
  - Exits **1** when duplicates are found (CI-friendly)
  - Exits **0** when clean

- **`tests/test_duplicate.py`** — 12 unit + CLI tests:
  - Identical same-gloss flagged, near-identical not flagged
  - Different gloss excluded even with identical frames
  - Incompatible dimensions skipped gracefully
  - Threshold tuning tested
  - CLI exit codes + JSON report verified

## Evidence

```
$ uv run pytest tests/test_duplicate.py -v
============================== 12 passed in 2.30s ===============================

$ uv run pytest -q
44 passed, 1 skipped in 3.99s
```

## Bounty

- Closes: mergeos-bounties/Loru#246
- Related: https://github.com/mergeos-bounties/mergeos/issues/1