### PR TITLE
feat: gloss coverage heatmap CLI (fixes #223)

### DIFF
--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -256,6 +256,73 @@ def gloss_compare(
         raise typer.Exit(code=1) from exc
 
 
+
+@gloss_app.command("coverage")
+def gloss_coverage(
+    directory: str | None = typer.Option(None, "--dir", help="Override samples directory"),
+    show_missing: bool = typer.Option(False, "--missing", "-m", help="Only show missing glosses"),
+) -> None:
+    """Show which DEFAULT_GLOSS entries have (or lack) landmark samples."""
+    from pathlib import Path
+    import json as _json
+
+    samples_dir = Path(directory) if directory else SAMPLES_DIR
+
+    # Recursive scan \u2014 includes subdirectories like asl/, vsl/, etc.
+    json_files = list(samples_dir.rglob("*.json"))
+
+    # Build: gloss_name -> list of relative paths
+    covered: dict[str, list[str]] = {}
+    for f in sorted(json_files):
+        try:
+            payload = _json.loads(f.read_text(encoding="utf-8"))
+        except (_json.JSONDecodeError, OSError):
+            continue
+        g = str(payload.get("gloss", "")).strip().lower() or f.stem.lower()
+        covered.setdefault(g, []).append(str(f.relative_to(samples_dir)))
+
+    table = Table(title="Gloss Coverage Heatmap")
+    table.add_column("Gloss", style="cyan")
+    table.add_column("Status", style="bold")
+    table.add_column("Samples", style="green")
+
+    covered_count = 0
+    missing: list[str] = []
+
+    for gloss in DEFAULT_GLOSS:
+        files = covered.get(gloss.strip().lower(), [])
+        if files:
+            covered_count += 1
+            if show_missing:
+                continue
+            status = "[bold green]COVERED[/bold green]"
+            samples = ", ".join(files[:3])
+            if len(files) > 3:
+                samples += f" (+{len(files) - 3})"
+        else:
+            missing.append(gloss)
+            status = "[bold red]MISSING[/bold red]"
+            samples = "\u2014"
+
+        if not show_missing:
+            table.add_row(gloss, status, samples)
+
+    if show_missing:
+        if not missing:
+            console.print("[green]All glosses covered![/green]")
+        else:
+            console.print(f"\n[bold red]{len(missing)} missing glosses:[/bold red]")
+            for m in missing:
+                console.print(f"  \u2022 {m}")
+    else:
+        console.print(table)
+
+    total = len(DEFAULT_GLOSS)
+    pct = covered_count / total * 100 if total else 0
+    color = "green" if pct == 100 else ("yellow" if pct >= 50 else "red")
+    console.print(f"\n[{color}]{covered_count}/{total} covered ({pct:.1f}%)\\[/{color}]")
+
+    raise typer.Exit(0 if pct == 100 else 1)
 @samples_app.command("list")
 def samples_list(
     gloss: str | None = typer.Option(

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1,0 +1,59 @@
+"""Tests for gloss coverage CLI command."""
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from loru.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def samples_tree() -> Path:
+    """Create a minimal samples directory with some glosses covered."""
+    base = Path(tempfile.mkdtemp())
+    (base / "hello.json").write_text(json.dumps({"gloss": "hello", "frames": [[0, 0, 0]]}))
+    (base / "thanks.json").write_text(json.dumps({"gloss": "thanks", "frames": [[0, 0, 0]]}))
+    # subdirectory with language-specific samples
+    asl_dir = base / "asl"
+    asl_dir.mkdir()
+    (asl_dir / "yes.json").write_text(
+        json.dumps({"gloss": "yes", "language": "asl", "frames": [[0, 0, 0]]})
+    )
+    yield base
+    import shutil
+    shutil.rmtree(base)
+
+
+def test_coverage_shows_summary(samples_tree: Path):
+    result = runner.invoke(app, ["gloss", "coverage", "--dir", str(samples_tree)])
+    assert result.exit_code == 1  # not 100% covered
+    assert "hello" in result.stdout
+    assert "thanks" in result.stdout
+    assert "yes" in result.stdout
+
+
+def test_coverage_missing_only(samples_tree: Path):
+    result = runner.invoke(app, ["gloss", "coverage", "--dir", str(samples_tree), "--missing"])
+    assert result.exit_code == 1
+    # should list missing glosses
+    assert "missing" in result.stdout.lower()
+
+
+def test_coverage_all_covered_exits_zero(tmp_path: Path):
+    """When all DEFAULT_GLOSS entries have samples, exit code is 0."""
+    from loru.models.vocab import DEFAULT_GLOSS
+    for g in DEFAULT_GLOSS:
+        (tmp_path / f"{g}.json").write_text(json.dumps({"gloss": g, "frames": [[0, 0, 0]]}))
+    result = runner.invoke(app, ["gloss", "coverage", "--dir", str(tmp_path)])
+    assert result.exit_code == 0
+
+
+def test_coverage_scans_subdirectories(samples_tree: Path):
+    """The coverage command should find samples in subdirectories like asl/."""
+    result = runner.invoke(app, ["gloss", "coverage", "--dir", str(samples_tree)])
+    # 'yes' is in asl/ subdirectory — should be found
+    assert "yes" in result.stdout


### PR DESCRIPTION
## Summary
Fixes #223 — CLI command showing which DEFAULT_GLOSS entries have landmark samples.

## Changes
- New `loru gloss coverage` command under `gloss` command group
- Recursive scan of `data/samples/` (includes subdirectories like `asl/`, `vsl/`, etc.)
- Rich heatmap table: COVERED (green) / MISSING (red)
- `--missing/-m` flag to show only uncovered glosses
- `--dir` override for testing
- Exit code 0 when 100% covered, 1 otherwise
- 4 new tests in `tests/test_cli_coverage.py`

## Validation
- ✅ 4 tests covering: summary view, --missing flag, 100% coverage exit code, subdirectory scanning
- ✅ No existing files modified beyond additions
