### PR TITLE
feat: add fingerspell sign packs (b, c, d, e, f)

### DIFF
--- a/data/sign-packs/fingerspell_b.json
+++ b/data/sign-packs/fingerspell_b.json
@@ -1,0 +1,53 @@
+{
+  "gloss": "fingerspell_b",
+  "wave": 2,
+  "sign_pack": {
+    "contributor": "laurentketterle-hub",
+    "notes": "Fingerspell letter B \u2014 palm forward, fingers extended up, thumb folded across palm",
+    "source_language": "en",
+    "gloss": "b",
+    "vocab": [
+      {
+        "form": "b",
+        "pos": "letter",
+        "gloss_en": "b",
+        "example_en": "The letter b in fingerspelling."
+      }
+    ],
+    "frames": [
+      {
+        "id": "b_frame_0",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "flat_open",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "hold",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "b_frame_1",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "flat_open",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "present",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "b_frame_2",
+        "duration_ms": 300,
+        "pose": {
+          "handshape": "flat_open",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "release",
+          "location": "neutral_space"
+        }
+      }
+    ]
+  }
+}

--- a/data/sign-packs/fingerspell_c.json
+++ b/data/sign-packs/fingerspell_c.json
@@ -1,0 +1,53 @@
+{
+  "gloss": "fingerspell_c",
+  "wave": 2,
+  "sign_pack": {
+    "contributor": "laurentketterle-hub",
+    "notes": "Fingerspell letter C \u2014 hand curved in C-shape, palm facing outward",
+    "source_language": "en",
+    "gloss": "c",
+    "vocab": [
+      {
+        "form": "c",
+        "pos": "letter",
+        "gloss_en": "c",
+        "example_en": "The letter c in fingerspelling."
+      }
+    ],
+    "frames": [
+      {
+        "id": "c_frame_0",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "c_shape",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "hold",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "c_frame_1",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "c_shape",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "arc",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "c_frame_2",
+        "duration_ms": 300,
+        "pose": {
+          "handshape": "c_shape",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "release",
+          "location": "neutral_space"
+        }
+      }
+    ]
+  }
+}

--- a/data/sign-packs/fingerspell_d.json
+++ b/data/sign-packs/fingerspell_d.json
@@ -1,0 +1,53 @@
+{
+  "gloss": "fingerspell_d",
+  "wave": 2,
+  "sign_pack": {
+    "contributor": "laurentketterle-hub",
+    "notes": "Fingerspell letter D \u2014 index finger extended up, other fingers folded, thumb touches middle finger tip",
+    "source_language": "en",
+    "gloss": "d",
+    "vocab": [
+      {
+        "form": "d",
+        "pos": "letter",
+        "gloss_en": "d",
+        "example_en": "The letter d in fingerspelling."
+      }
+    ],
+    "frames": [
+      {
+        "id": "d_frame_0",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "one_index",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "hold",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "d_frame_1",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "one_index",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "trace_circle",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "d_frame_2",
+        "duration_ms": 300,
+        "pose": {
+          "handshape": "one_index",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "release",
+          "location": "neutral_space"
+        }
+      }
+    ]
+  }
+}

--- a/data/sign-packs/fingerspell_e.json
+++ b/data/sign-packs/fingerspell_e.json
@@ -1,0 +1,53 @@
+{
+  "gloss": "fingerspell_e",
+  "wave": 2,
+  "sign_pack": {
+    "contributor": "laurentketterle-hub",
+    "notes": "Fingerspell letter E \u2014 fingers folded down, thumb touches side of hand",
+    "source_language": "en",
+    "gloss": "e",
+    "vocab": [
+      {
+        "form": "e",
+        "pos": "letter",
+        "gloss_en": "e",
+        "example_en": "The letter e in fingerspelling."
+      }
+    ],
+    "frames": [
+      {
+        "id": "e_frame_0",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "claw_spread",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "hold",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "e_frame_1",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "claw_spread",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "press",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "e_frame_2",
+        "duration_ms": 300,
+        "pose": {
+          "handshape": "claw_spread",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "release",
+          "location": "neutral_space"
+        }
+      }
+    ]
+  }
+}

--- a/data/sign-packs/fingerspell_f.json
+++ b/data/sign-packs/fingerspell_f.json
@@ -1,0 +1,53 @@
+{
+  "gloss": "fingerspell_f",
+  "wave": 2,
+  "sign_pack": {
+    "contributor": "laurentketterle-hub",
+    "notes": "Fingerspell letter F \u2014 index and thumb form circle, other three fingers extended up",
+    "source_language": "en",
+    "gloss": "f",
+    "vocab": [
+      {
+        "form": "f",
+        "pos": "letter",
+        "gloss_en": "f",
+        "example_en": "The letter f in fingerspelling."
+      }
+    ],
+    "frames": [
+      {
+        "id": "f_frame_0",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "f_hand",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "hold",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "f_frame_1",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "f_hand",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "wiggle",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "f_frame_2",
+        "duration_ms": 300,
+        "pose": {
+          "handshape": "f_hand",
+          "palm_orientation": "outward",
+          "non_dominant": "rest",
+          "movement": "release",
+          "location": "neutral_space"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Fingerspell Sign Packs: B, C, D, E, F

Adds sign-pack data for ASL fingerspelling letters B through F.

Closes #197, Closes #198, Closes #199, Closes #200, Closes #201

### Sign packs added

| Letter | File | Frames | Handshape |
|--------|------|--------|-----------|
| B | data/sign-packs/fingerspell_b.json | 3 | flat_open |
| C | data/sign-packs/fingerspell_c.json | 3 | c_shape |
| D | data/sign-packs/fingerspell_d.json | 3 | one_index |
| E | data/sign-packs/fingerspell_e.json | 3 | claw_spread |
| F | data/sign-packs/fingerspell_f.json | 3 | f_hand |

### Format
- Follows existing `data/sign-packs/fingerspell_x.json` format
- Each pack includes: gloss, contributor, notes, source_language, vocab entry, and 3 annotated pose frames
- Source: synthetic-prototype with distinct handshape and motion descriptions
- Language: ASL (American Sign Language) fingerspelling conventions

### Verification
```bash
pip install -e ".[dev]"
loru data list
pytest -q
ruff check src tests
```

**Contributor:** laurentketterle-hub  
**License:** MIT (as per project)  
**Ethics:** Synthetic prototypes generated from documented ASL handshape references. No video capture was performed.
**Wallet:** 0x153b65CCA4B2d69a9feD7be6E9C19c10736e8517