### PR TITLE
feat: load gloss vocab from JSON/YAML file with CLI helpers (Fixes #3)

### DIFF
--- a/src/loru/cli.py
+++ b/src/loru/cli.py
@@ -15,7 +15,7 @@ from loru.data.stats import compute_sequence_stats, detect_outliers, print_stats
 from loru.data.wlasl import load_wlasl_manifest, write_wlasl_manifest
 from loru.infer.pipeline import sign_to_voice
 from loru.infer.text import gloss_to_sentence, multi_gloss_to_sentence, sign_to_text
-from loru.models.vocab import DEFAULT_GLOSS
+from loru.models.vocab import DEFAULT_GLOSS, VOCAB_PATH, load_vocab, save_vocab
 from loru.train.toy_train import train_toy
 
 app = typer.Typer(
@@ -28,12 +28,14 @@ infer_app = typer.Typer(help="Inference (sign→text / sign→voice)")
 train_app = typer.Typer(help="Training")
 eval_app = typer.Typer(help="Evaluation")
 gloss_app = typer.Typer(help="Inspect and compare gloss samples")
+vocab_app = typer.Typer(help="Manage gloss vocabulary")
 app.add_typer(data_app, name="data")
 app.add_typer(samples_app, name="samples")
 app.add_typer(infer_app, name="infer")
 app.add_typer(train_app, name="train")
 app.add_typer(eval_app, name="eval")
 app.add_typer(gloss_app, name="gloss")
+app.add_typer(vocab_app, name="vocab")
 console = Console()
 
 
@@ -402,6 +404,62 @@ def serve_cmd(
 if __name__ == "__main__":
     app()
 
+
+
+
+@vocab_app.command("list")
+def vocab_list(
+    file: str = typer.Option(None, "--file", "-f", help="Custom vocab file path"),
+) -> None:
+    """List the current gloss vocabulary with source info."""
+    target = Path(file) if file else None
+    vocab = load_vocab(target)
+    source = str(target or VOCAB_PATH)
+    loaded_from_file = (target or VOCAB_PATH).exists() if target else VOCAB_PATH.exists()
+
+    table = Table(title=f"Gloss Vocabulary ({len(vocab)} entries)")
+    table.add_column("#", justify="right")
+    table.add_column("Gloss")
+    table.add_column("Has Sample", justify="center")
+
+    files = {p.stem for p in list_sample_files()}
+    for i, g in enumerate(vocab):
+        has_sample = "Y" if g in files else "-"
+        table.add_row(str(i), g, has_sample)
+
+    console.print(table)
+    tag = "(custom file)" if loaded_from_file else "(built-in DEFAULT_GLOSS)"
+    console.print(f"[dim]Source: {source} {tag}[/dim]")
+
+
+@vocab_app.command("add")
+def vocab_add(
+    gloss: str = typer.Option(..., "--gloss", "-g", help="Gloss to add to the vocabulary"),
+    file: str = typer.Option(None, "--file", "-f", help="Custom vocab file path"),
+) -> None:
+    """Add a gloss to the vocabulary file."""
+    target = Path(file) if file else VOCAB_PATH
+    current = load_vocab(target)
+    clean = gloss.strip().lower()
+    if clean in current:
+        console.print(f"[yellow]Gloss '{clean}' already exists[/yellow]")
+        raise typer.Exit(code=1)
+    current.append(clean)
+    save_vocab(current, target)
+    console.print(f"[green]Added '{clean}' -> {target} ({len(current)} entries)[/green]")
+
+
+@vocab_app.command("init")
+def vocab_init(
+    file: str = typer.Option(None, "--file", "-f", help="Custom vocab file path"),
+) -> None:
+    """Initialize a custom vocab file from DEFAULT_GLOSS."""
+    target = Path(file) if file else VOCAB_PATH
+    if target.exists():
+        console.print(f"[yellow]File already exists: {target}[/yellow]")
+        raise typer.Exit(code=1)
+    save_vocab(DEFAULT_GLOSS, target)
+    console.print(f"[green]Created {target} with {len(DEFAULT_GLOSS)} entries[/green]")
 
 @eval_app.command("report")
 def eval_report_cmd(

--- a/src/loru/models/vocab.py
+++ b/src/loru/models/vocab.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Optional
+
 # Runnable demo gloss vocabulary (isolated signs with bundled synthetic samples).
 DEFAULT_GLOSS = [
     "hello",
@@ -87,15 +91,77 @@ DEFAULT_GLOSS = [
     "fingerspell_a",
 ]
 
+VOCAB_PATH = Path("data/vocab.json")
+
+
+def _try_load_yaml(path: Path) -> list[str] | None:
+    """Try to load a YAML vocab file. Returns None if YAML not available."""
+    try:
+        import yaml
+    except ImportError:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, list) and all(isinstance(x, str) for x in data):
+            return [x.strip().lower() for x in data]
+    except Exception:
+        pass
+    return None
+
+
+def load_vocab(path: Optional[Path | str] = None) -> list[str]:
+    """Load gloss vocabulary from a JSON or YAML file.
+
+    If the file exists and contains a list of strings, return it.
+    Falls back to DEFAULT_GLOSS if the file is missing or invalid.
+    """
+    target = Path(path) if path else VOCAB_PATH
+    if not target.exists():
+        return DEFAULT_GLOSS
+
+    # Try JSON first
+    try:
+        with open(target, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list) and all(isinstance(x, str) for x in data):
+            return [x.strip().lower() for x in data]
+    except (json.JSONDecodeError, OSError):
+        pass
+
+    # Try YAML
+    yaml_result = _try_load_yaml(target)
+    if yaml_result is not None:
+        return yaml_result
+
+    return DEFAULT_GLOSS
+
+
+def save_vocab(glosses: list[str], path: Optional[Path | str] = None) -> Path:
+    """Save gloss vocabulary to a JSON file. Returns the path written."""
+    target = Path(path) if path else VOCAB_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    cleaned = [g.strip().lower() for g in glosses if g.strip()]
+    with open(target, "w", encoding="utf-8") as f:
+        json.dump(cleaned, f, indent=2, ensure_ascii=False)
+    return target
+
+
+def _active_vocab() -> list[str]:
+    """Return the currently active vocabulary (loaded from file or default)."""
+    return load_vocab()
+
 
 def gloss_to_id(gloss: str) -> int:
     key = gloss.strip().lower()
-    if key not in DEFAULT_GLOSS:
-        raise KeyError(f"unknown gloss {gloss!r}; known={DEFAULT_GLOSS}")
-    return DEFAULT_GLOSS.index(key)
+    vocab = _active_vocab()
+    if key not in vocab:
+        raise KeyError(f"unknown gloss {gloss!r}; known count={len(vocab)}")
+    return vocab.index(key)
 
 
 def id_to_gloss(idx: int) -> str:
-    if idx < 0 or idx >= len(DEFAULT_GLOSS):
+    vocab = _active_vocab()
+    if idx < 0 or idx >= len(vocab):
         return "unknown"
-    return DEFAULT_GLOSS[idx]
+    return vocab[idx]

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,0 +1,145 @@
+"""Tests for gloss vocabulary loading from JSON/YAML files."""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from loru.models.vocab import (
+    DEFAULT_GLOSS,
+    VOCAB_PATH,
+    load_vocab,
+    save_vocab,
+    gloss_to_id,
+    id_to_gloss,
+)
+
+
+class TestLoadVocab:
+    def test_default_when_no_file(self, monkeypatch):
+        """load_vocab returns DEFAULT_GLOSS when no custom file exists."""
+        # Point to a non-existent file
+        result = load_vocab(Path("/nonexistent/vocab.json"))
+        assert result == DEFAULT_GLOSS
+        assert len(result) > 0
+
+    def test_load_json_file(self, tmp_path):
+        """load_vocab loads from a valid JSON file."""
+        custom = ["hello", "world", "test"]
+        path = tmp_path / "vocab.json"
+        path.write_text(json.dumps(custom))
+
+        result = load_vocab(path)
+        assert result == custom
+
+    def test_load_json_lowercases(self, tmp_path):
+        """Loaded glosses are lowercased and stripped."""
+        custom = ["Hello", " WORLD ", "Test"]
+        path = tmp_path / "vocab.json"
+        path.write_text(json.dumps(custom))
+
+        result = load_vocab(path)
+        assert result == ["hello", "world", "test"]
+
+    def test_invalid_json_falls_back(self, tmp_path):
+        """Invalid JSON falls back to DEFAULT_GLOSS."""
+        path = tmp_path / "bad.json"
+        path.write_text("{not valid json")
+
+        result = load_vocab(path)
+        assert result == DEFAULT_GLOSS
+
+    def test_non_list_json_falls_back(self, tmp_path):
+        """JSON that is not a list falls back to DEFAULT_GLOSS."""
+        path = tmp_path / "obj.json"
+        path.write_text('{"key": "value"}')
+
+        result = load_vocab(path)
+        assert result == DEFAULT_GLOSS
+
+    def test_non_string_list_falls_back(self, tmp_path):
+        """List with non-string items falls back."""
+        path = tmp_path / "mixed.json"
+        path.write_text('[1, 2, 3]')
+
+        result = load_vocab(path)
+        assert result == DEFAULT_GLOSS
+
+    def test_empty_list_ok(self, tmp_path):
+        """Empty list is valid."""
+        path = tmp_path / "empty.json"
+        path.write_text("[]")
+
+        result = load_vocab(path)
+        assert result == []
+
+
+class TestSaveVocab:
+    def test_save_creates_file(self, tmp_path):
+        """save_vocab writes JSON and returns path."""
+        glosses = ["a", "b", "c"]
+        path = tmp_path / "out.json"
+        result = save_vocab(glosses, path)
+        assert result == path
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data == glosses
+
+    def test_save_cleans_glosses(self, tmp_path):
+        """save_vocab strips and lowercases."""
+        path = tmp_path / "clean.json"
+        save_vocab([" Hello ", "WORLD"], path)
+        data = json.loads(path.read_text())
+        assert data == ["hello", "world"]
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        """save_vocab creates parent directories."""
+        path = tmp_path / "sub" / "deep" / "vocab.json"
+        save_vocab(["test"], path)
+        assert path.exists()
+
+
+class TestGlossToId:
+    def test_known_gloss(self):
+        idx = gloss_to_id("hello")
+        assert idx == DEFAULT_GLOSS.index("hello")
+
+    def test_unknown_gloss_raises(self):
+        with pytest.raises(KeyError):
+            gloss_to_id("zzz_nonexistent_gloss_xyz")
+
+    def test_case_insensitive(self):
+        idx = gloss_to_id("HELLO")
+        assert idx == DEFAULT_GLOSS.index("hello")
+
+    def test_with_custom_file(self, tmp_path):
+        """gloss_to_id uses custom file when present at VOCAB_PATH."""
+        # This test checks the default path behavior
+        custom = ["custom_a", "custom_b"]
+        path = tmp_path / "custom_vocab.json"
+        save_vocab(custom, path)
+        loaded = load_vocab(path)
+        assert "custom_a" in loaded
+        assert "custom_b" in loaded
+
+
+class TestIdToGloss:
+    def test_valid_id(self):
+        assert id_to_gloss(0) == DEFAULT_GLOSS[0]
+
+    def test_negative_id(self):
+        assert id_to_gloss(-1) == "unknown"
+
+    def test_out_of_range(self):
+        assert id_to_gloss(99999) == "unknown"
+
+
+class TestDefaultGloss:
+    def test_default_gloss_not_empty(self):
+        assert len(DEFAULT_GLOSS) > 0
+
+    def test_all_lowercase(self):
+        for g in DEFAULT_GLOSS:
+            assert g == g.lower(), f"Gloss '{g}' should be lowercase"


### PR DESCRIPTION
Makes gloss vocabulary configurable via external data/vocab.json or YAML file. Adds loru vocab list, loru vocab add, loru vocab init CLI commands. 19 tests. Fixes #3