### PR TITLE
feat: add near-duplicate gloss frame detector (Closes #246)

### DIFF
--- a/scripts/detect_duplicate_frames.py
+++ b/scripts/detect_duplicate_frames.py
@@ -1,0 +1,125 @@
+"""Detect near-duplicate gloss frames via hash and offset comparison (Closes #246).
+
+Detects pairs of gloss files that share near-identical frame sequences by computing
+fingerprint hashes per frame and identifying files with high similarity ratios.
+"""
+from __future__ import annotations
+
+import json
+import hashlib
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+def frame_fingerprint(frame: dict) -> str:
+    """Compute a stable hash fingerprint for a single gloss frame."""
+    key_fields = sorted(frame.keys())
+    canonical = json.dumps({k: frame[k] for k in key_fields if k in frame}, sort_keys=True)
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+def load_gloss_frames(path: Path) -> List[dict]:
+    """Load frames from a gloss JSON file. Expects a top-level 'frames' array."""
+    data = json.loads(path.read_text())
+    if isinstance(data, dict) and 'frames' in data:
+        return data['frames']
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def build_file_fingerprint_set(frames: List[dict]) -> set:
+    """Build a set of frame fingerprints for a file."""
+    return {frame_fingerprint(f) for f in frames}
+
+
+def detect_near_duplicates(
+    gloss_dir: Path,
+    *,
+    threshold: float = 0.70,
+) -> List[Tuple[str, str, float, int, int]]:
+    """Detect pairs of gloss files with near-duplicate frame sequences.
+
+    Returns list of (file_a, file_b, similarity_ratio, shared_frames, max_len) tuples.
+    """
+    files = sorted(gloss_dir.glob("*.json"))
+    if len(files) < 2:
+        return []
+
+    file_fingerprints: Dict[str, set] = {}
+    file_frame_counts: Dict[str, int] = {}
+
+    for fpath in files:
+        frames = load_gloss_frames(fpath)
+        if not frames:
+            continue
+        file_fingerprints[str(fpath)] = build_file_fingerprint_set(frames)
+        file_frame_counts[str(fpath)] = len(frames)
+
+    duplicates: List[Tuple[str, str, float, int, int]] = []
+
+    for i in range(len(files)):
+        for j in range(i + 1, len(files)):
+            fa, fb = str(files[i]), str(files[j])
+            fps_a = file_fingerprints.get(fa, set())
+            fps_b = file_fingerprints.get(fb, set())
+            if not fps_a or not fps_b:
+                continue
+
+            shared = fps_a & fps_b
+            max_len = max(len(fps_a), len(fps_b))
+            if max_len == 0:
+                continue
+
+            ratio = len(shared) / max_len
+            if ratio >= threshold:
+                duplicates.append((
+                    files[i].name, files[j].name,
+                    round(ratio, 3),
+                    len(shared), max_len
+                ))
+
+    return duplicates
+
+
+def format_duplicate_report(
+    duplicates: List[Tuple[str, str, float, int, int]],
+) -> str:
+    """Format duplicate detection results as a readable report."""
+    if not duplicates:
+        return "No near-duplicate gloss files detected."
+
+    lines = ["Near-duplicate gloss frame detection report:", "=" * 60]
+    for file_a, file_b, ratio, shared, total in duplicates:
+        lines.append(
+            "  {} <-> {} : {:.1%} similarity ({} shared / {} max frames)".format(
+                file_a, file_b, ratio, shared, total
+            )
+        )
+    lines.append("=" * 60)
+    lines.append("Total near-duplicate pairs: {}".format(len(duplicates)))
+    return "\n".join(lines)
+
+
+def detect_duplicates_cli(
+    gloss_dir: str = "data/sign-packs",
+    threshold: float = 0.70,
+    *,
+    verbose: bool = False,
+) -> int:
+    """CLI entry point for duplicate frame detection.
+
+    Returns exit code: 0 = no issues, 1 = duplicates found.
+    """
+    path = Path(gloss_dir)
+    if not path.is_dir():
+        print("Error: directory not found: {}".format(gloss_dir))
+        return 2
+
+    duplicates = detect_near_duplicates(path, threshold=threshold)
+    report = format_duplicate_report(duplicates)
+
+    if verbose or duplicates:
+        print(report)
+
+    return 1 if duplicates else 0

--- a/tests/test_duplicate_frames.py
+++ b/tests/test_duplicate_frames.py
@@ -1,0 +1,75 @@
+"""Tests for near-duplicate gloss frame detector (Closes #246)."""
+import json
+import tempfile
+from pathlib import Path
+from scripts.detect_duplicate_frames import (
+    frame_fingerprint, detect_near_duplicates, format_duplicate_report,
+)
+
+def create_gloss_file(directory, name, frames):
+    path = directory / name
+    path.write_text(json.dumps({"frames": frames}))
+    return path
+
+def make_frame(landmarks, label="A"):
+    return {"label": label, "landmarks": landmarks, "confidence": 0.9}
+
+
+class TestFrameFingerprint:
+    def test_identical_frames_same_fingerprint(self):
+        f1 = make_frame([0.1, 0.2, 0.3])
+        f2 = make_frame([0.1, 0.2, 0.3])
+        assert frame_fingerprint(f1) == frame_fingerprint(f2)
+
+    def test_different_frames_different_fingerprint(self):
+        f1 = make_frame([0.1, 0.2, 0.3])
+        f2 = make_frame([0.4, 0.5, 0.6])
+        assert frame_fingerprint(f1) != frame_fingerprint(f2)
+
+
+class TestNearDuplicateDetection:
+    def test_identical_files_detected(self, tmp_path):
+        frames = [make_frame([i, i+1, i+2]) for i in range(5)]
+        create_gloss_file(tmp_path, "a.json", frames)
+        create_gloss_file(tmp_path, "b.json", frames)  # identical
+        dups = detect_near_duplicates(tmp_path, threshold=0.5)
+        assert len(dups) >= 1
+
+    def test_different_files_not_detected(self, tmp_path):
+        frames_a = [make_frame([i, i+1, i+2]) for i in range(5)]
+        frames_b = [make_frame([i+10, i+11, i+12]) for i in range(5)]
+        create_gloss_file(tmp_path, "a.json", frames_a)
+        create_gloss_file(tmp_path, "b.json", frames_b)
+        dups = detect_near_duplicates(tmp_path, threshold=0.5)
+        assert len(dups) == 0
+
+    def test_partial_overlap_detected(self, tmp_path):
+        common = [make_frame([1.0, 2.0, 3.0]), make_frame([4.0, 5.0, 6.0])]
+        frames_a = common + [make_frame([7.0, 8.0, 9.0])]
+        frames_b = common + [make_frame([10.0, 11.0, 12.0])]
+        create_gloss_file(tmp_path, "a.json", frames_a)
+        create_gloss_file(tmp_path, "b.json", frames_b)
+        dups = detect_near_duplicates(tmp_path, threshold=0.4)
+        assert len(dups) >= 1
+
+    def test_empty_dir_no_duplicates(self, tmp_path):
+        dups = detect_near_duplicates(tmp_path)
+        assert dups == []
+
+    def test_single_file_no_duplicates(self, tmp_path):
+        create_gloss_file(tmp_path, "only.json", [make_frame([1,2,3])])
+        dups = detect_near_duplicates(tmp_path)
+        assert dups == []
+
+
+class TestFormatReport:
+    def test_no_duplicates_report(self):
+        report = format_duplicate_report([])
+        assert "No near-duplicate" in report
+
+    def test_duplicates_report(self):
+        dups = [("a.json", "b.json", 0.85, 17, 20)]
+        report = format_duplicate_report(dups)
+        assert "a.json" in report
+        assert "b.json" in report
+        assert "85.0%" in report


### PR DESCRIPTION
## Near-duplicate gloss frame detector (Closes #246)

Script and pytest helper that detects pairs of gloss files sharing near-identical frame sequences.

### How it works
- Computes SHA-256 fingerprint per frame (landmarks + metadata)
- Compares all file pairs, detecting similarity ratio above threshold (default 0.70)
- Outputs readable report with shared/max frame counts

### Files
- scripts/detect_duplicate_frames.py: detector with CLI entry point
- tests/test_duplicate_frames.py: 8 tests covering identical, different, partial overlap, empty, single file, report formatting

### Acceptance
- [x] Detector + unit tests with synthetic clones