### PR TITLE
feat: add gloss coverage heatmap CLI (Closes #223)

### DIFF
--- a/scripts/gloss_coverage_heatmap.py
+++ b/scripts/gloss_coverage_heatmap.py
@@ -1,0 +1,170 @@
+"""Gloss coverage heatmap CLI — shows which DEFAULT_GLOSS entries lack samples (Closes #223)."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from collections import defaultdict
+from typing import Dict, List, Set
+
+
+DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"
+
+
+def load_default_gloss() -> Dict[str, set]:
+    """Load DEFAULT_GLOSS entries from sign-packs metadata. Returns {gloss_id: {expected_samples}}."""
+    gloss_map = defaultdict(set)
+    sign_packs_dir = DATA_DIR / "sign-packs"
+    if not sign_packs_dir.is_dir():
+        return dict(gloss_map)
+
+    for fpath in sorted(sign_packs_dir.glob("*.json")):
+        try:
+            data = json.loads(fpath.read_text())
+        except (json.JSONDecodeError, KeyError):
+            continue
+
+        frames = data.get("frames", [])
+        for frame in frames:
+            gloss_id = frame.get("gloss", frame.get("label", ""))
+            if gloss_id:
+                gloss_map[gloss_id].add(fpath.stem)
+
+    return dict(gloss_map)
+
+
+def load_available_samples() -> Dict[str, int]:
+    """Load available sample files and count them per gloss."""
+    samples = defaultdict(int)
+    samples_dir = DATA_DIR / "samples"
+    if not samples_dir.is_dir():
+        return dict(samples)
+
+    for fpath in sorted(samples_dir.glob("**/*.json")):
+        try:
+            data = json.loads(fpath.read_text())
+        except (json.JSONDecodeError, KeyError):
+            continue
+
+        gloss_id = data.get("gloss", data.get("label", ""))
+        if gloss_id:
+            samples[gloss_id] += 1
+
+    return dict(samples)
+
+
+def compute_coverage(
+    gloss_map: Dict[str, set],
+    samples: Dict[str, int],
+) -> Dict[str, dict]:
+    """Compute coverage stats: covered, uncovered, sample count, expected count."""
+    coverage = {}
+    all_glosses = set(gloss_map.keys()) | set(samples.keys())
+
+    for gloss_id in sorted(all_glosses):
+        expected = len(gloss_map.get(gloss_id, set()))
+        available = samples.get(gloss_id, 0)
+        covered = available > 0
+        percentage = round(available / max(expected, 1) * 100, 1) if expected > 0 else (100.0 if available > 0 else 0.0)
+
+        coverage[gloss_id] = {
+            "gloss": gloss_id,
+            "expected": expected,
+            "available": available,
+            "covered": covered,
+            "coverage_pct": min(percentage, 100.0),
+        }
+
+    return coverage
+
+
+def format_heatmap(coverage: Dict[str, dict]) -> str:
+    """Format coverage as a color-coded terminal heatmap."""
+    if not coverage:
+        return "No gloss data found."
+
+    total = len(coverage)
+    covered_count = sum(1 for v in coverage.values() if v["covered"])
+    uncovered_count = total - covered_count
+
+    lines = [
+        "Gloss Coverage Heatmap",
+        "=" * 60,
+        "Total glosses: {} | Covered: {} | Uncovered: {}".format(total, covered_count, uncovered_count),
+        "Coverage: {:.1%}".format(covered_count / max(total, 1)),
+        "",
+    ]
+
+    # Color-coded bar per gloss (ASCII)
+    BAR_WIDTH = 40
+    for gloss_id, info in sorted(coverage.items()):
+        pct = info["coverage_pct"]
+        filled = int(pct / 100 * BAR_WIDTH)
+        empty = BAR_WIDTH - filled
+        bar = "#" * filled + "." * empty
+
+        if pct >= 75:
+            symbol = "GREEN "
+        elif pct >= 25:
+            symbol = "YELLOW"
+        elif pct > 0:
+            symbol = "ORANGE"
+        else:
+            symbol = "RED   "
+
+        lines.append(
+            "{} [{}] {:20s} {:3d}/{:3d} ({:5.1f}%)".format(
+                symbol, bar, gloss_id[:20], info["available"], info["expected"], pct
+            )
+        )
+
+    lines.append("")
+    lines.append("Uncovered glosses (need samples):")
+    uncovered = [g for g, v in coverage.items() if not v["covered"]]
+    if uncovered:
+        for g in uncovered:
+            lines.append("  - {} (expected from {})".format(g, ", ".join(sorted(coverage[g].get("_packs", []))) if "_packs" in coverage[g] else ""))
+    else:
+        lines.append("  None — all glosses have at least one sample!")
+
+    return "\n".join(lines)
+
+
+def format_json(coverage: Dict[str, dict]) -> str:
+    """Export coverage as JSON."""
+    summary = {
+        "total": len(coverage),
+        "covered": sum(1 for v in coverage.values() if v["covered"]),
+        "uncovered": sum(1 for v in coverage.values() if not v["covered"]),
+        "glosses": list(coverage.values()),
+    }
+    return json.dumps(summary, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gloss coverage heatmap CLI")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--uncovered-only", action="store_true", help="Show only uncovered glosses")
+    args = parser.parse_args()
+
+    gloss_map = load_default_gloss()
+    samples = load_available_samples()
+    coverage = compute_coverage(gloss_map, samples)
+
+    # Attach pack info for uncovered display
+    for gloss_id, info in coverage.items():
+        info["_packs"] = list(gloss_map.get(gloss_id, set()))
+
+    if args.uncovered_only:
+        coverage = {k: v for k, v in coverage.items() if not v["covered"]}
+
+    if args.json:
+        print(format_json(coverage))
+    else:
+        print(format_heatmap(coverage))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gloss_coverage.py
+++ b/tests/test_gloss_coverage.py
@@ -1,0 +1,76 @@
+"""Tests for gloss coverage heatmap CLI (Closes #223)."""
+import json
+from pathlib import Path
+from scripts.gloss_coverage_heatmap import (
+    load_default_gloss, load_available_samples, compute_coverage,
+    format_heatmap, format_json,
+)
+
+
+def create_sign_pack(directory, name, glosses):
+    path = directory / "sign-packs" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"frames": [{"gloss": g} for g in glosses]}))
+
+def create_sample(directory, name, gloss):
+    path = directory / "samples" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"gloss": gloss, "data": {}}))
+
+
+class TestComputeCoverage:
+    def test_all_covered(self):
+        gloss_map = {"HELLO": {"pack1"}, "BYE": {"pack1"}}
+        samples = {"HELLO": 3, "BYE": 1}
+        cov = compute_coverage(gloss_map, samples)
+        assert cov["HELLO"]["covered"]
+        assert cov["BYE"]["covered"]
+
+    def test_partial_coverage(self):
+        gloss_map = {"A": {"p1"}, "B": {"p1"}}
+        samples = {"A": 2}
+        cov = compute_coverage(gloss_map, samples)
+        assert cov["A"]["covered"]
+        assert not cov["B"]["covered"]
+        assert cov["A"]["coverage_pct"] >= 100.0
+
+    def test_zero_expected_with_sample(self):
+        gloss_map = {}
+        samples = {"X": 1}
+        cov = compute_coverage(gloss_map, samples)
+        assert cov["X"]["covered"]
+        assert cov["X"]["expected"] == 0
+
+    def test_empty_inputs(self):
+        cov = compute_coverage({}, {})
+        assert cov == {}
+
+
+class TestFormatHeatmap:
+    def test_heatmap_output(self):
+        cov = {
+            "HELLO": {"gloss": "HELLO", "expected": 2, "available": 2, "covered": True, "coverage_pct": 100.0},
+            "BYE": {"gloss": "BYE", "expected": 1, "available": 0, "covered": False, "coverage_pct": 0.0},
+        }
+        heatmap = format_heatmap(cov)
+        assert "HELLO" in heatmap
+        assert "BYE" in heatmap
+        assert "Covered: 1" in heatmap or "1" in heatmap
+
+    def test_empty_heatmap(self):
+        heatmap = format_heatmap({})
+        assert "No gloss data" in heatmap
+
+    def test_coverage_percentage_displayed(self):
+        cov = {"TEST": {"gloss": "TEST", "expected": 5, "available": 3, "covered": True, "coverage_pct": 60.0}}
+        heatmap = format_heatmap(cov)
+        assert "60.0%" in heatmap
+
+
+class TestFormatJson:
+    def test_json_output(self):
+        cov = {"A": {"gloss": "A", "expected": 1, "available": 1, "covered": True, "coverage_pct": 100.0}}
+        out = format_json(cov)
+        data = json.loads(out)
+        assert data["total"] == 1
+        assert data["covered"] == 1


### PR DESCRIPTION
## Gloss coverage heatmap CLI (Closes #223)

CLI tool that shows which DEFAULT_GLOSS entries have sample coverage and which lack samples.

### Features
- Scans sign-packs for expected glosses and samples for available data
- ASCII heatmap with color-coded bars (GREEN/YELLOW/ORANGE/RED)
- Coverage statistics per gloss (expected vs available, percentage)
- `--json` flag for machine-readable output
- `--uncovered-only` to focus on gaps

### Files
- scripts/gloss_coverage_heatmap.py: CLI module
- tests/test_gloss_coverage.py: 8 tests

### Acceptance
- [x] Command + tests