### PR TITLE
[25 MRG] Sign pack: fingerspell_h (fingerspell) — Closes #203

### DIFF
--- a/data/sign-packs/fingerspell_h.json
+++ b/data/sign-packs/fingerspell_h.json
@@ -1,0 +1,53 @@
+{
+  "gloss": "fingerspell_h",
+  "wave": 2,
+  "sign_pack": {
+    "contributor": "laurentketterle-hub",
+    "notes": "Fingerspell letter H \u2014 index and middle fingers extended together, palm facing inward, sweep outward",
+    "source_language": "en",
+    "gloss": "h",
+    "vocab": [
+      {
+        "form": "h",
+        "pos": "letter",
+        "gloss_en": "h",
+        "example_en": "The letter H in fingerspelling."
+      }
+    ],
+    "frames": [
+      {
+        "id": "h_frame_0",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "H_hand",
+          "palm_orientation": "inward",
+          "non_dominant": "rest",
+          "movement": "hold",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "h_frame_1",
+        "duration_ms": 400,
+        "pose": {
+          "handshape": "H_hand",
+          "palm_orientation": "inward",
+          "non_dominant": "rest",
+          "movement": "sweep_outward",
+          "location": "neutral_space"
+        }
+      },
+      {
+        "id": "h_frame_2",
+        "duration_ms": 300,
+        "pose": {
+          "handshape": "H_hand",
+          "palm_orientation": "inward",
+          "non_dominant": "rest",
+          "movement": "release",
+          "location": "neutral_space"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Changes
- Added `data/sign-packs/fingerspell_h.json` — ASL fingerspell letter H sign pack
- 3 frames with H-handshape, palm-inward orientation, sweep-outward movement

Fixes #203